### PR TITLE
fix: corrects title on Flutter web3wallet migration

### DIFF
--- a/docs/walletkit/upgrade/from-web3wallet-flutter.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-flutter.mdx
@@ -1,13 +1,14 @@
 ---
-title: Upgrade from Web3Modal to AppKit
-pagination_next: 
+title: Upgrade from Web3Wallet to WalletKit
+pagination_next:
 displayed_sidebar: mainSidebar
 ---
+
 import Table from '../../components/Table'
 import PlatformTabs from '../../components/PlatformTabs'
 import PlatformTabItem from '../../components/PlatformTabItem'
 
-# Upgrade from Web3Modal to Reown AppKit for Flutter
+# Upgrade from Web3Wallet to Reown WalletKit for Flutter
 
 This document outlines the steps to migrate from the old `walletconnect_flutter_v2` package to the new `reown_walletkit` packages in your Flutter project.
 


### PR DESCRIPTION
Noticed the title is incorrect while setting up the deprecation notices