### PR TITLE
Docs update: Fix grammar and broken link

### DIFF
--- a/docs/appkit/flutter/core/custom-chains.mdx
+++ b/docs/appkit/flutter/core/custom-chains.mdx
@@ -2,7 +2,7 @@
 
 ## Custom Networks addition and selection
 
-AppKit already comes with a list of supported networks inside of `ReownAppKitModalNetworks` class. You can get default supported EVM networks by selecting `ReownAppKitModalNetworks.supported['eip155']` and, currently, only EVM Networks are supported (non-EVM support will come soon). Check the list of [suppoted networks](https://github.com/reown-com/blockchain-api/blob/master/SUPPORTED_CHAINS.md#list-of-supported-chains)
+AppKit already comes with a list of supported networks inside of `ReownAppKitModalNetworks` class. You can get default supported EVM networks by selecting `ReownAppKitModalNetworks.supported['eip155']` and, currently, only EVM Networks are supported (non-EVM support will come soon). Check the list of [supported networks](https://github.com/walletconnect/blockchain-api/blob/master/SUPPORTED_CHAINS.md#list-of-supported-chains)
 
 This class also comes with extra networks `ReownAppKitModalNetworks.extra['eip155']` and test networks `ReownAppKitModalNetworks.test['eip155']`, however, these are not included in the supported list by default.
 


### PR DESCRIPTION
## Description:

- Changing `suppoted` to `supported` to fix grammar. 
- Fixing a broken link. 