### PR TITLE
Fix typo/spelling mistake in doc - rainbowkit migration

### DIFF
--- a/docs/appkit/migration/from-rainbowkit-next.mdx
+++ b/docs/appkit/migration/from-rainbowkit-next.mdx
@@ -87,7 +87,7 @@ export const metadata = {
 export const networks = [mainnet, arbitrum]
 
 // Create wagmiAdapter
-onst wagmiAdapter = new WagmiAdapter({
+const wagmiAdapter = new WagmiAdapter({
   ssr: true,
   networks,
   projectId


### PR DESCRIPTION
Fix a spelling error at step no 4 where
onst wagmiAdapter = new WagmiAdapter({
  ssr: true,
  networks,
  projectId
})

into 

const wagmiAdapter = new WagmiAdapter({
  ssr: true,
  networks,
  projectId
})