### PR TITLE
Docs update: Adding a warning message for create-react-app

### DIFF
--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -27,6 +27,11 @@ Choose one of these ethereum libraries or solana to get started.
 
 ## Installation
 
+:::warning
+If you are setting up your React app, please **do not use** `npx create-react-app`, as it has been deprecated. Using it may cause dependency issues. 
+Instead, please use [Vite](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) to create your React app. You can set it up by running `npm create vite@latest`.
+:::
+
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana"]}>
 <PlatformTabItem value="wagmi">
 


### PR DESCRIPTION
## Description

A lot of users set up their React app by running `npx create-react-app` command and this causes dependency issues as this command has been deprecated. This PR adds a cautionary message stating the same and asking users to use Vite to set up their React app. 

## Tests

Tested locally with Docusaurus. 