### PR TITLE
Installation command missing instructions for Solana adapter wallets 

### DIFF
--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -52,7 +52,7 @@ npm install @reown/appkit @reown/appkit-adapter-ethers ethers
 <PlatformTabItem value="solana">
 
 ```bash npm2yarn
-npm install @reown/appkit @reown/appkit-adapter-solana
+npm install @reown/appkit @reown/appkit-adapter-solana @solana/wallet-adapter-wallets
 ```
 
 </PlatformTabItem>


### PR DESCRIPTION
Users have to install @solana/wallet-adapter-wallets separately, instead the docs should have instructions to install it too.