### PR TITLE
Docs update: Creating the doc page for telegram mini apps

### DIFF
--- a/docs/appkit/features/telegram-mini-apps.mdx
+++ b/docs/appkit/features/telegram-mini-apps.mdx
@@ -1,0 +1,78 @@
+---
+pagination_next: appkit/react/transactions/swaps
+title: Swaps
+---
+
+import Button from '../../components/button'
+import Wrapper from '../../components/Home/Wrapper'
+
+import reactLogo from '../../../static/assets/home/reactLogo.png'
+import nextjsLogo from '../../../static/assets/home/nextjsLogo.png'
+import vueLogo from '../../../static/assets/home/vueLogo.png'
+import javascriptLogo from '../../../static/assets/home/javascriptLogo.png'
+
+## Introducing Telegram Mini Apps
+
+If you are building Web3 mini-app on telegram, Appkit provides the perfect out of the box interface for your users to connect their self-custodial Wallet or create their first wallet using Email or Social login. 
+
+## Features
+
+By integrating Appkit into your mini-app you will get the following features out of the box:
+
+- **Email & Social Login**
+- **Swaps**
+- **Onramp**
+- **Transaction History**
+- **Network Switching**
+
+:::info
+The "Try Demo" button below redirects you to a Telegram bot. Click on its profile, then click the "Open App" button. This will open AppKit Lab, allowing you to interact with it directly from Telegram.
+:::
+
+<Button name="Try Demo" url="https://t.me/appkit_test_ggr_bot" />
+
+## Before you get started
+
+Please ensure that you are using the latest version of `@walletconnect/modal-core` and `@walletconnect/modal-ui` packages. 
+
+```bash npm2yarn
+npm install @walletconnect/modal-core @walletconnect/modal-ui
+```
+
+## Get Started
+
+<Wrapper
+  type="large"
+  fit={false}
+  items={[
+    {
+      name: 'React',
+      type: 'react',
+      description: 'Get started with AppKit in React.',
+      icon: reactLogo,
+      href: '../react/core/installation'
+    },
+    {
+      name: 'Next.js',
+      type: 'next',
+      description: 'Get started with AppKit in Next.js.',
+      icon: nextjsLogo,
+      href: '../next/core/installation',
+      isWhite: true
+    },
+    {
+      name: 'Vue',
+      type: 'vue',
+      description: 'Get started with AppKit in Vue.',
+      icon: vueLogo,
+      href: '../vue/core/installation'
+    },
+    {
+      name: 'JavaScript',
+      type: 'javascript',
+      description: 'Get started with AppKit in JavaScript.',
+      icon: javascriptLogo,
+      href: '../javascript/core/installation'
+    }
+  ]}
+/>

--- a/docs/appkit/features/telegram-mini-apps.mdx
+++ b/docs/appkit/features/telegram-mini-apps.mdx
@@ -1,6 +1,6 @@
 ---
 pagination_next: appkit/react/transactions/swaps
-title: Swaps
+title: Telegram MiniApps
 ---
 
 import Button from '../../components/button'

--- a/sidebars.js
+++ b/sidebars.js
@@ -236,7 +236,8 @@ module.exports = {
                 { type: 'doc', label: 'On-Ramp', id: 'appkit/features/onramp' },
                 { type: 'doc', label: 'Notifications', id: 'appkit/features/notifications' },
                 { type: 'doc', label: 'Solana', id: 'appkit/features/solana' },
-                { type: 'doc', label: 'Multichain', id: 'appkit/features/multichain' }
+                { type: 'doc', label: 'Multichain', id: 'appkit/features/multichain' },
+                { type: 'doc', label: 'Telegram Mini Apps', id:'appkit/features/telegram-mini-apps'}
               ]
             },
             {


### PR DESCRIPTION
## Description:

Reown's AppKit now supports Telegram Mini apps right out of the box. This PR creates a simple doc page that contains general info about this feature and the packages that a developer needs to install before they proceed with setting up AppKit. 

## Tests:

Tested locally with Docusauras. 