### PR TITLE
Docs update: Adding info about security reports on FAQs

### DIFF
--- a/docs/advanced/faq.md
+++ b/docs/advanced/faq.md
@@ -35,3 +35,7 @@ You are more than welcome to utilize a custom URI parameter during testing. Howe
 ## Why is self-hosting not an option at this time? Are there plans to make this possible in the future?
 
 We understand the desire for developers to self-host their own relay. We share this vision, and have embarked on a decentralization roadmap in order to achieve this. By the end of this summer, we will launch a permissioned network and invite a select group of partners to participate in this crucial first phase. Our objective is to make self-hosting relay a reality with the creation of the decentralized WalletConnect Network, and we appreciate your patience as we progress in this enormous mission.
+
+## How do I report a security issue?
+
+Please consult our [security.txt](https://reown.com/.well-known/security.txt)


### PR DESCRIPTION
## Description

The docs FAQ section does not touch up on how developers can report a security issue that they spot. This PR adds it to the docs. 

## Tests

Tested locally with Docusauras. 