### PR TITLE
Docs update: Relocate essential NextJS installation instructions for …

### DIFF
--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -58,6 +58,24 @@ npm install @reown/appkit @reown/appkit-adapter-ethers ethers
 npm install @reown/appkit @reown/appkit-adapter-solana
 ```
 
+## Extra configuration
+
+Next.js relies on [SSR](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering). This means some specific steps are required to make Web3Modal work properly.
+
+- Add the following code in the `next.config.js` file
+
+```ts
+// Path: next.config.js
+const nextConfig = {
+  webpack: config => {
+    config.externals.push('pino-pretty', 'lokijs', 'encoding')
+    return config
+  }
+}
+```
+
+- [Learn more about SSR with Wagmi](https://wagmi.sh/react/guides/ssr)
+
 </PlatformTabItem>
 </PlatformTabs>
 
@@ -187,21 +205,3 @@ function Components() {
   <SolanaPrograms />
 </PlatformTabItem>
 </PlatformTabs>
-
-## Extra configuration
-
-Next.js relies on [SSR](https://nextjs.org/docs/pages/building-your-application/rendering/server-side-rendering). This means some specific steps are required to make Web3Modal work properly.
-
-- Add the following code in the `next.config.js` file
-
-```ts
-// Path: next.config.js
-const nextConfig = {
-  webpack: config => {
-    config.externals.push('pino-pretty', 'lokijs', 'encoding')
-    return config
-  }
-}
-```
-
-- [Learn more about SSR with Wagmi](https://wagmi.sh/react/guides/ssr)


### PR DESCRIPTION
…easier access

When installing the appkit package for NextJS, the "Extra Configuration" section is essential to running the local server. If the configuration isn't implemented, you're unable to proceed with any of the "Implementation" section. 

Therefore, it makes much more sense for it be located before the "Implementation" section.

This change would've saved me a good chunk of time as I didn't bother scrolling to the bottom. I didn't scroll to the bottom because I was still stuck on the installation step.