### PR TITLE
Docs update: Update WalletKit upgrade guide for iOS and Android 

### DIFF
--- a/docs/walletkit/upgrade/from-web3wallet-android.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-android.mdx
@@ -1,11 +1,10 @@
 ---
-title: Upgrade from Web3Modal to AppKit for Android
+title: Upgrade from Web3Wallet to WalletKit for Android
 pagination_next: 
 displayed_sidebar: mainSidebar
 ---
 
-
-# Upgrade from Web3Wallet to Reown WalletKit for Android
+## Upgrade to Reown WalletKit
 
 This upgrade guide helps developers transition from using the Web3Wallet library to the WalletKit within reown-kotlin. The guide involves updating imports, modifying class references and updating artefacts dependencies. Follow these steps to ensure a smooth migration.
 
@@ -79,3 +78,15 @@ If you have ProGuard rules defined remember to update
 ### Step 5. Test Your Changes
 
 After updating all references to Web3Wallet to use WalletKit, thoroughly test your application to ensure that all functionalities work as expected.
+
+## Pairing Expiry
+
+Currently, Dapps create a new pairing whenever the user selects the **"Connect Wallet"** button, instead of reusing existing pairings. Although pairings were not intended to be reused, they were being persisted for 30 days, causing unnecessary resource usage for both Dapps and wallet clients, including redundant socket connections. 
+
+This led to an accumulation of stale pairings in wallets, resulting in degraded efficiency and increased resource consumption. To address this issue, we have introduced changes to how pairings are managed to ensure more efficient connection handling.
+
+Pairings were never intended to be listed in the wallet, and wallets should only display active sessions to users.
+
+### Steps for Migration
+
+Wallets are no longer expected to handle pairing-related methods. If your wallet has been listing pairings, please replace this with listing active sessions instead.

--- a/docs/walletkit/upgrade/from-web3wallet-flutter.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-flutter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Upgrade from Web3Wallet to WalletKit
+title: Upgrade from Web3Wallet to WalletKit for Flutter
 pagination_next:
 displayed_sidebar: mainSidebar
 ---
@@ -8,7 +8,7 @@ import Table from '../../components/Table'
 import PlatformTabs from '../../components/PlatformTabs'
 import PlatformTabItem from '../../components/PlatformTabItem'
 
-# Upgrade from Web3Wallet to Reown WalletKit for Flutter
+## Upgrade to Reown WalletKit
 
 This document outlines the steps to migrate from the old `walletconnect_flutter_v2` package to the new `reown_walletkit` packages in your Flutter project.
 

--- a/docs/walletkit/upgrade/from-web3wallet-ios.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-ios.mdx
@@ -1,11 +1,11 @@
 ---
-title: Upgrade from Web3Modal to AppKit
+title: Upgrade from Web3Wallet to WalletKit for iOS
 pagination_next: 
 displayed_sidebar: mainSidebar
 ---
 
 
-# Upgrade from Web3Wallet to Reown WalletKit for iOS
+## Upgrade to Reown WalletKit
 
 This upgrade guide helps developers transition from using the Web3Wallet library to the WalletKit within reown-swift. The guide involves updating import statements, modifying instance references, changing configuration methods, and updating repository URLs for CocoaPods and Swift Package Manager (SPM). 
 
@@ -85,3 +85,15 @@ If you are using CocoaPods to manage dependencies, update your Podfile to use th
 ### Step 6. Test Your Changes
 
 After updating all references to Web3Wallet to use WalletKit, thoroughly test your application to ensure that all functionalities work as expected.
+
+## Pairing Expiry
+
+Currently, Dapps create a new pairing whenever the user selects the **"Connect Wallet"** button, instead of reusing existing pairings. Although pairings were not intended to be reused, they were being persisted for 30 days, causing unnecessary resource usage for both Dapps and wallet clients, including redundant socket connections. 
+
+This led to an accumulation of stale pairings in wallets, resulting in degraded efficiency and increased resource consumption. To address this issue, we have introduced changes to how pairings are managed to ensure more efficient connection handling.
+
+Pairings were never intended to be listed in the wallet, and wallets should only display active sessions to users.
+
+### Steps for Migration
+
+Wallets are no longer expected to handle pairing-related methods. If your wallet has been listing pairings, please replace this with listing active sessions instead.

--- a/docs/walletkit/upgrade/from-web3wallet-react-native.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-react-native.mdx
@@ -1,11 +1,11 @@
 ---
-title: Upgrade from Web3Modal to AppKit
+title: Upgrade from Web3Wallet to WalletKit for React Native
 pagination_next: 
 displayed_sidebar: mainSidebar
 ---
 
 
-# Upgrade from Web3Wallet to Reown WalletKit for React Native
+## Upgrade to Reown WalletKit
 
 This document outlines the steps to migrate from the old `@walletconnect/web3wallet` package to the new `@reown/walletkit` packages in your project.
 

--- a/docs/walletkit/upgrade/from-web3wallet-unity.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-unity.mdx
@@ -1,12 +1,12 @@
 ---
-title: Upgrade from Web3Wallet to WalletKit
+title: Upgrade from Web3Wallet to WalletKit for .NET
 pagination_next: 
 displayed_sidebar: mainSidebar
 ---
 
 import Table from '../../components/Table'
 
-# Upgrade from Web3Wallet to Reown WalletKit for .NET
+## Upgrade to Reown WalletKit
 
 This document outlines the steps to migrate from the old `WalletConnect.Web3Wallet` package to the new `Reown.WalletKit` package in your .NET project.
 

--- a/docs/walletkit/upgrade/from-web3wallet-web.mdx
+++ b/docs/walletkit/upgrade/from-web3wallet-web.mdx
@@ -1,10 +1,10 @@
 ---
-title: Upgrade from Web3Modal to AppKit
+title: Upgrade from Web3Wallet to WalletKit for Web
 pagination_next: 
 displayed_sidebar: mainSidebar
 ---
 
-# Upgrade from Web3Wallet to Reown WalletKit for Web
+## Upgrade to Reown WalletKit
 
 This document outlines the steps to migrate from the old `@walletconnect/web3wallet` package to the new `@reown/walletkit` packages in your project.
 


### PR DESCRIPTION
## Description

The current WalletKit upgrade guide does not mention about deprecation of the pairing feature for iOS and Android. This PR adds information about this and how one should migrate. 

## Tests

Tested locally with Docusauru.