### PR TITLE
Missing instruction in installation guide

### DIFF
--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -55,7 +55,7 @@ npm install @reown/appkit @reown/appkit-adapter-ethers ethers
 <PlatformTabItem value="solana">
 
 ```bash npm2yarn
-npm install @reown/appkit @reown/appkit-adapter-solana
+npm install @reown/appkit @reown/appkit-adapter-solana @solana/wallet-adapter-wallets
 ```
 
 </PlatformTabItem>


### PR DESCRIPTION
Installation guide for Next must have installation instruction for @solana/wallet-adapter-wallets as users have to install manually. For completeness, we should have it in the guide.