### PR TITLE
Docs update: Updating supported chains info for social and email login feature

### DIFF
--- a/docs/appkit/features/socials.mdx
+++ b/docs/appkit/features/socials.mdx
@@ -20,10 +20,9 @@ AppKit supports the following providers:
 
 ## Supported Chains
 
-Our Email & Socials feature supports the following chains:
-+ Algorand, Arbitrum, Astar zkEVM, Base, Berachain, Binance, Celo, Chiliz, Cronos, Etherlink, Fantom, Flare, Harmony, Hedera, Horizen EON, Loopring, Moonbeam, Near, Optimism, RARI Chain, Sei, ZetaChain, zkSync and XDC Network
-+ Solana, Solana Devnet and Solana Testnet
+Email and Social login are supported for all EVM-compatible chains listed in Viem. If the EVM-compatible chain is included in the `viem/chains` package, it should be supported for email and social login.
 
+Email and Social login is also available for Solana, Solana Devnet, and Solana Testnet.
 
 ## Get Started
 

--- a/docs/appkit/features/socials.mdx
+++ b/docs/appkit/features/socials.mdx
@@ -20,7 +20,7 @@ AppKit supports the following providers:
 
 ## Supported Chains
 
-Email and Social login are supported for all **EVM-compatible chains** listed in Viem. If the EVM-compatible chain is included in the `viem/chains` package, it should be supported for email and social login.
+Email and Social login are supported for all **EVM-compatible chains** listed in Viem. If the EVM-compatible chain is included in the `viem/chains` [package](https://github.com/wevm/viem/blob/main/src/chains/index.ts), it should be supported for email and social login.
 
 Email and Social login is also available for **Solana, Solana Devnet, and Solana Testnet**.
 

--- a/docs/appkit/features/socials.mdx
+++ b/docs/appkit/features/socials.mdx
@@ -20,9 +20,9 @@ AppKit supports the following providers:
 
 ## Supported Chains
 
-Email and Social login are supported for all EVM-compatible chains listed in Viem. If the EVM-compatible chain is included in the `viem/chains` package, it should be supported for email and social login.
+Email and Social login are supported for all **EVM-compatible chains** listed in Viem. If the EVM-compatible chain is included in the `viem/chains` package, it should be supported for email and social login.
 
-Email and Social login is also available for Solana, Solana Devnet, and Solana Testnet.
+Email and Social login is also available for **Solana, Solana Devnet, and Solana Testnet**.
 
 ## Get Started
 


### PR DESCRIPTION
## Description

`AppKit v1.1.0` uses all the chains available in the `viem/chains` package under the hood. These chains can be used out of the box by importing them from `@reown/appkit/networks`. As part of this release, the social and email login features of AppKit are now supported with all EVM chains listed in the `viem/chains` package.

This PR updates the existing information on supported chains for social and email login to reflect the latest changes.

## Tests

Tested locally with Docusaurus. 

