### PR TITLE
fix: delete a library from the upgrade in vue

### DIFF
--- a/docs/appkit/upgrade/to-reown-appkit-web.mdx
+++ b/docs/appkit/upgrade/to-reown-appkit-web.mdx
@@ -49,7 +49,7 @@ npm install @reown/appkit @reown/appkit-adapter-wagmi
 To upgrade from Web3Modal v5 to Reown AppKit start by removing Web3Modal v5 dependencies `@web3modal/ethereum` and `@web3modal/vue`. Now you can install AppKit library and update `Wagmi` and `Viem`.
 
 ```bash npm2yarn
-npm install @reown/appkit @reown/appkit-adapter-wagmi @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi
 ```
 
 </PlatformTabItem>


### PR DESCRIPTION
Delete react library from vue upgrade guide

https://reown-docs-git-fix-bad-vue-upgrade-reown-com.vercel.app/appkit/upgrade/to-reown-appkit-web?platform=vue