### PR TITLE
fix(walletkit): fix broken links to integration test examples

### DIFF
--- a/docs/walletkit/web/usage.mdx
+++ b/docs/walletkit/web/usage.mdx
@@ -184,7 +184,7 @@ await walletKit.pair({ uri })
 ### 🛠️ Usage examples
 
 - [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/a50c8eb5a10666f25911713c5358e78f1ca576d6/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx#L264)
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L55)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L55)
 
 ### ⚠️ Expected Errors
 
@@ -221,7 +221,7 @@ walletKit.on('session_proposal', async proposal => {
 ### 🛠️ Usage examples
 
 - [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/a50c8eb5a10666f25911713c5358e78f1ca576d6/advanced/wallets/react-wallet-v2/src/views/SessionProposalModal.tsx#L287)
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L79)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L79)
 
 ### ⚠️ Expected Errors
 
@@ -280,7 +280,7 @@ const response = {
 ### 🛠️ Usage examples
 
 - [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/a50c8eb5a10666f25911713c5358e78f1ca576d6/advanced/wallets/react-wallet-v2/src/views/SessionSignModal.tsx#L36)
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L165)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L165)
 
 ### ⚠️ Expected Errors
 
@@ -361,7 +361,7 @@ await walletKit.updateSession({ topic: session.topic, namespaces: updatedNamespa
 ### 🛠️ Usage examples
 
 - [in a demo wallet app](https://github.com/WalletConnect/web-examples/blob/a50c8eb5a10666f25911713c5358e78f1ca576d6/advanced/wallets/react-wallet-v2/src/pages/session.tsx#L77)
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L98)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L98)
 
 ### ⚠️ Expected Errors
 
@@ -397,7 +397,7 @@ await acknowledged()
 
 ### 🛠️ Usage examples
 
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L130)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L130)
 
 ### ⚠️ Expected Errors
 
@@ -428,7 +428,7 @@ await walletKit.disconnectSession({
 
 ### 🛠️ Usage examples
 
-- [in integration tests](https://github.com/WalletConnect/walletconnect-monorepo/blob/v2.0/packages/walletkit/test/sign.spec.ts#L222)
+- [in integration tests](https://github.com/reown-com/reown-walletkit-js/blob/main/packages/walletkit/test/sign.spec.ts#L222)
 
 ### ⚠️ Expected Errors
 


### PR DESCRIPTION
## Context

- Was pointed out to me that these links are 404'ing
- The internal pkg has been moved out to its own repo so GH can't redirect automatically.