### PR TITLE
Docs update: updating theming docs to showcase examples

### DIFF
--- a/docs/appkit/shared/theming.mdx
+++ b/docs/appkit/shared/theming.mdx
@@ -1,5 +1,9 @@
 import Table from '../../components/Table'
 
+You can fully customize the theme for the AppKit integration in your Web3 app. Here are some examples.
+- [**Wormfare**](https://dashboard.wormfare.com/purchase)
+- [**BeraPong**](https://berapong.com/)
+
 ## ThemeMode
 
 By default `themeMode` option will be set to user system settings 'light' or 'dark'. But you can override it like this:


### PR DESCRIPTION
## Description

The current theming docs lacks examples of existing Web3 apps that have a fully customized integration of AppKit. This PR addresses that. 

## Tests

Tested locally with Docusaurus.