### PR TITLE
Fix: remove addNetworks & allowunsupportedchain

### DIFF
--- a/docs/appkit/next/core/hooks.mdx
+++ b/docs/appkit/next/core/hooks.mdx
@@ -60,7 +60,7 @@ Hook for accessing network data and methods.
 import { useAppKitNetwork } from "@reown/appkit/react";
 
 export default Component(){
-  const { caipNetwork, caipNetworkId, chainId, switchNetwork, addNetwork } = useAppKitNetwork()
+  const { caipNetwork, caipNetworkId, chainId, switchNetwork } = useAppKitNetwork()
 }
 ```
 
@@ -70,7 +70,6 @@ export default Component(){
 - `caipNetworkId`: The current network id in CAIP format
 - `chainId`: The current chain id
 - `switchNetwork`: Function to switch the network. Accepts a `caipNetwork` object as argument.
-- `addNetwork`: Function to add a new network. Accepts a `caipNetwork` object as argument.
 
 :::info
 See how to import or create a networks [here](/appkit/react/core/custom-networks).

--- a/docs/appkit/react/core/hooks.mdx
+++ b/docs/appkit/react/core/hooks.mdx
@@ -61,7 +61,7 @@ Hook for accessing network data and methods.
 import { useAppKitNetwork } from "@reown/appkit/react";
 
 export default Component(){
-  const { caipNetwork, caipNetworkId, chainId, switchNetwork, addNetwork } = useAppKitNetwork()
+  const { caipNetwork, caipNetworkId, chainId, switchNetwork } = useAppKitNetwork()
 }
 ```
 
@@ -71,7 +71,6 @@ export default Component(){
 - `caipNetworkId`: The current network id in CAIP format
 - `chainId`: The current chain id
 - `switchNetwork`: Function to switch the network. Accepts a `caipNetwork` object as argument.
-- `addNetwork`: Function to add a new network. Accepts a `caipNetwork` object as argument.
 
 :::info
 See how to import or create a networks [here](/appkit/react/core/custom-networks).

--- a/docs/appkit/shared/options.mdx
+++ b/docs/appkit/shared/options.mdx
@@ -112,17 +112,6 @@ createAppKit({
 })
 ```
 
-## allowUnsupportedChain
-
-Allow users to switch to an unsupported chain.
-
-```ts
-createAppKit({
-  //...
-  allowUnsupportedChain: true
-})
-```
-
 ## tokens
 
 Tokens for AppKit to show the user's balance of. Each key represents the chain id of the token's blockchain.

--- a/docs/appkit/vue/core/composables.mdx
+++ b/docs/appkit/vue/core/composables.mdx
@@ -60,7 +60,7 @@ Composable function for accessing network data and methods.
 import { useAppKitNetwork } from "@reown/appkit/react";
 
 export default Component(){
-  const { caipNetwork, caipNetworkId, chainId, switchNetwork, addNetwork } = useAppKitNetwork()
+  const { caipNetwork, caipNetworkId, chainId, switchNetwork } = useAppKitNetwork()
 }
 ```
 
@@ -70,7 +70,6 @@ export default Component(){
 - `caipNetworkId`: The current network id in CAIP format
 - `chainId`: The current chain id
 - `switchNetwork`: Function to switch the network. Accepts a `caipNetwork` object as argument.
-- `addNetwork`: Function to add a new network. Accepts a `caipNetwork` object as argument.
 
 :::info
 See how to import or create a networks [here](/appkit/react/core/custom-networks).


### PR DESCRIPTION
+ Remove addNetworks from useAppKitNetwork
+ Remove allowunsupportedchain

https://reown-docs-git-fix-remove-addnetwork-from-usea-b35ce4-reown-com.vercel.app/appkit/next/core/hooks#useappkitnetwork

https://reown-docs-git-fix-remove-addnetwork-from-usea-b35ce4-reown-com.vercel.app/appkit/vue/core/composables

close -> https://github.com/reown-com/appkit/issues/3192