### PR TITLE
chore(rpc): explicit note finalization on `broadcast` param

### DIFF
--- a/docs/advanced/multichain/rpc-reference/bitcoin-rpc.md
+++ b/docs/advanced/multichain/rpc-reference/bitcoin-rpc.md
@@ -197,7 +197,7 @@ This method can be used to request the signature of a Partially Signed Bitcoin T
             * `address` : `String` - _(Required)_ The address whose private key to use for signing.
             * `index` : `Integer` - _(Required)_ Specifies which input to sign.
             * `sighashTypes` : `Integer[]` - _(Optional)_ Specifies which part(s) of the transaction the signature commits to. Default is `[1]`.
-    * `broadcast` : `Boolean` - _(Optional)_ Whether to broadcast the transaction after signing it. Default is `false`.
+    * `broadcast` : `Boolean` - _(Optional)_ Whether to finalize and broadcast the transaction after signing it. Default is `false`.
 
 ### Returns
 * `Object`

--- a/docs/advanced/multichain/rpc-reference/dogecoin-rpc.md
+++ b/docs/advanced/multichain/rpc-reference/dogecoin-rpc.md
@@ -179,7 +179,7 @@ This method can be used to request the signature of a Partially Signed Bitcoin T
             * `address` : `String` - _(Required)_ The address whose private key to use for signing.
             * `index` : `Integer` - _(Required)_ Specifies which input to sign.
             * `sighashTypes` : `Integer[]` - _(Optional)_ Specifies which part(s) of the transaction the signature commits to. Default is `[1]`.
-    * `broadcast` : `Boolean` - _(Optional)_ Whether to broadcast the transaction after signing it. Default is `false`.
+    * `broadcast` : `Boolean` - _(Optional)_ Whether to finalize and broadcast the transaction after signing it. Default is `false`.
 
 ### Returns
 * `Object`

--- a/docs/advanced/multichain/rpc-reference/litecoin-rpc.md
+++ b/docs/advanced/multichain/rpc-reference/litecoin-rpc.md
@@ -189,7 +189,7 @@ This method can be used to request the signature of a Partially Signed Bitcoin T
             * `address` : `String` - _(Required)_ The address whose private key to use for signing.
             * `index` : `Integer` - _(Required)_ Specifies which input to sign.
             * `sighashTypes` : `Integer[]` - _(Optional)_ Specifies which part(s) of the transaction the signature commits to. Default is `[1]`.
-    * `broadcast` : `Boolean` - _(Optional)_ Whether to broadcast the transaction after signing it. Default is `false`.
+    * `broadcast` : `Boolean` - _(Optional)_ Whether to finalize and broadcast the transaction after signing it. Default is `false`.
 
 ### Returns
 * `Object`


### PR DESCRIPTION
## Context

- Most current implementations implicitly associate `broadcast = true` to mean `finalize = true`.
- This is stated for example in the `sats-connect` docs: https://docs.xverse.app/sats-connect/bitcoin-methods/signpsbt


### Change

- Update the wording of the optional `broadcast` param on the `signPsbt` method to make this expected relationship explicit.