### PR TITLE
Docs Update: Replacing all references to WalletConnect Explorer with WalletGuide

### DIFF
--- a/docs/advanced/walletconnectmodal/options.mdx
+++ b/docs/advanced/walletconnectmodal/options.mdx
@@ -88,7 +88,7 @@ new WalletConnectModal({
 
 #### projectId (required)
 
-Your project’s unique identifier that can be obtained at [cloud.reown.com](https://cloud.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet&version=2). Defaults to `undefined`.
+Your project’s unique identifier that can be obtained at [cloud.reown.com](https://cloud.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `undefined`.
 
 ```ts
 projectId: string
@@ -151,7 +151,7 @@ const onCopyClipboard = (value: string) => {
 
 #### explorerRecommendedWalletIds (optional)
 
-Allows to override default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to completely disable recommended wallets, you can set this option to `NONE`. Defaults to `undefined`.
+Allows to override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to completely disable recommended wallets, you can set this option to `NONE`. Defaults to `undefined`.
 
 ```ts
 explorerRecommendedWalletIds: string[] | 'NONE'
@@ -165,7 +165,7 @@ explorerRecommendedWalletIds={[
 
 #### explorerExcludedWalletIds (optional)
 
-Allows to exclude wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to exclude all wallets, you can set this option to `ALL`, however if `explorerRecommendedWalletIds` were defined, they will still be fetched. Defaults to `undefined`.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to exclude all wallets, you can set this option to `ALL`, however if `explorerRecommendedWalletIds` were defined, they will still be fetched. Defaults to `undefined`.
 
 ```ts
 explorerExcludedWalletIds: string[] | 'ALL'
@@ -194,7 +194,7 @@ accentColor = '#9090FF'
 
 #### Explorer recommended wallets
 
-Allows to set default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define a list of wallets ids you'd like to prioritise (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to set default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define a list of wallets ids you'd like to prioritise (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```kotlin
 val recommendedWalletsIds = listOf<String>(
@@ -217,7 +217,7 @@ WalletConnectModal.initialize(
 
 #### Explorer excluded wallets
 
-Allows to exclude wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```kotlin
 val excludedWalletIds = listOf<String>(
@@ -324,7 +324,7 @@ You can change it at any time with the `setOptionalNamespaces` method.
 
 #### recommendedWalletIds (optional)
 
-Allows to override default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
+Allows to override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
 
 ```javascript
 final Set<String> recommendedWalletIds = {
@@ -337,7 +337,7 @@ final Set<String> recommendedWalletIds = {
 
 The `excludedWalletState` Determines the state of the excluded wallets. Defaults to `ExcludedWalletState.list`.
 
-If the `excludedWalletState` is `ExcludedWalletState.list`, the `excludedWalletIds` will be used to remove items from the list of wallets returned from the [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). If the `excludedWalletState` is `ExcludedWalletState.all`, all wallets will be excluded except for the ones defined in `recommendedWalletIds`.
+If the `excludedWalletState` is `ExcludedWalletState.list`, the `excludedWalletIds` will be used to remove items from the list of wallets returned from the [WalletGuide](https://walletguide.walletconnect.network/). If the `excludedWalletState` is `ExcludedWalletState.all`, all wallets will be excluded except for the ones defined in `recommendedWalletIds`.
 
 </PlatformTabItem>
 
@@ -378,7 +378,7 @@ ConnectOptions = new ConnectOptions
 
 #### IncludedWalletIds
 
-Allows to override default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
+Allows to override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
 
 ```csharp
 IncludedWalletIds = new[]
@@ -390,7 +390,7 @@ IncludedWalletIds = new[]
 
 #### ExcludedWalletIds
 
-Allows to exclude wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. Defaults to `null`.
 
 ```csharp
 ExcludedWalletIds = new[]

--- a/docs/api/notify/usage.mdx
+++ b/docs/api/notify/usage.mdx
@@ -385,7 +385,7 @@ func onSign(message: String) -> SigningResult {
 
 To enable seamless communication between a Dapp and a wallet, the wallet must first establish a Notify Subscription. This crucial step allows the Dapp and its associated services to publish notify messages directly to the wallet. Upon granting permission for the wallet's iOS application to display Push Notifications, users will experience real-time updates in the form of push notifications on their devices. For an enhanced user experience, consider subscribing to the `notifyMessagePublisher` channel. This option ensures that notify messages are delivered promptly when the app is active and a web socket connection is established, keeping users informed and engaged.
 
-To subscribe to dapp's notify messages first fetch publicly discoverable dapps with WalletConnet explorer:
+To subscribe to dapp's notify messages first fetch publicly discoverable dapps with WalletGuide :
 
 https://explorer-api.walletconnect.com/v3/dapps?projectId={your_project_id}&is_notify_enabled=true
 
@@ -395,7 +395,7 @@ and request a subscription directly from the wallet:
 public func subscribe(metadata: AppMetadata, account: Account, onSign: @escaping SigningCallback) async throws {
 ```
 
-`metadata` - metadata object of publicly discoverable dapp fetched from WalletConnect explorer
+`metadata` - metadata object of publicly discoverable dapp fetched from WalletGuide
 
 `account` - an account you want to associate a sebscription with
 

--- a/docs/appkit/android/core/options.mdx
+++ b/docs/appkit/android/core/options.mdx
@@ -2,7 +2,7 @@
 
 ### Explorer recommended wallets
 
-Allows to set default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to set default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```kotlin
 val recommendedWalletsIds = listOf<String>(
@@ -25,7 +25,7 @@ AppKit.initialize(
 
 ### Explorer excluded wallets
 
-Allows to exclude wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```kotlin
 val excludedWalletIds = listOf<String>(

--- a/docs/appkit/flutter/core/options.mdx
+++ b/docs/appkit/flutter/core/options.mdx
@@ -51,7 +51,7 @@ These are the set of namespaces that will be requested to the wallet you are con
 
 ### featuredWalletIds:
 
-Allows to override default recommended wallets that are fetched from the API. You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the [Reown Explorer](https://reown.com/explorer?type=wallet) by clicking on the copy icon of desired wallet card.
+Allows to override default recommended wallets that are fetched from the API. You can define an array of wallet ids you'd like to prioritize (order is respected). You can get these ids from the [WalletGuide](https://walletguide.walletconnect.network/) by clicking on the copy icon of desired wallet card.
 
 ```javascript
 final Set<String> featuredWalletIds = {

--- a/docs/appkit/ios/core/options.mdx
+++ b/docs/appkit/ios/core/options.mdx
@@ -2,7 +2,7 @@
 
 ### Explorer recommended wallets
 
-Allows to set default recommended wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to set default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```swift
 AppKit.configure(
@@ -14,7 +14,7 @@ AppKit.configure(
 
 ### Explorer excluded wallets
 
-Allows to exclude wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```swift
 AppKit.configure(

--- a/docs/appkit/react-native/core/options.mdx
+++ b/docs/appkit/react-native/core/options.mdx
@@ -126,7 +126,7 @@ createAppKit({
 
 Select wallets that are going to be shown on the modal's main view. Array of wallet IDs defined will be prioritized (order is respected).
 These wallets will also show up first in `All Wallets` view.
-You can find the wallets ids in [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet)
+You can find the wallets ids in [WalletGuide](https://walletguide.walletconnect.network/)
 
 ```ts
 createAppKit({
@@ -140,7 +140,7 @@ createAppKit({
 
 ## includeWalletIds
 
-Override default recommended wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet).
+Override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/).
 Array of wallet ids defined will be shown (order is respected).
 Unlike `featuredWalletIds`, these wallets will be the **only** ones shown in `All Wallets` view and as recommended wallets.
 You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card.
@@ -157,7 +157,7 @@ createAppKit({
 
 ## excludeWalletIds
 
-Exclude wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet).
+Exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/).
 Array of wallet ids defined will be excluded.
 All other wallets will be shown in respective places.
 You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card.

--- a/docs/appkit/shared/options.mdx
+++ b/docs/appkit/shared/options.mdx
@@ -100,7 +100,7 @@ createAppKit({
 Select wallets that are going to be shown on the modal's main view. Default wallets are MetaMask and Trust Wallet.
 Array of wallet ids defined will be prioritized (order is respected).
 These wallets will also show up first in `All Wallets` view.
-You can find the wallets ids in [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet)
+You can find the wallets ids in [WalletGuide](https://walletguide.walletconnect.network/)
 
 ```ts
 createAppKit({
@@ -356,7 +356,7 @@ Wallets that are either not included or excluded **won't** be able to connect to
 
 ### includeWalletIds
 
-Override default recommended wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet).
+Override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/).
 Array of wallet ids defined will be shown (order is respected).
 Unlike `featuredWalletIds`, these wallets will be the **only** ones shown in `All Wallets` view and as recommended wallets.
 You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card.
@@ -373,7 +373,7 @@ createAppKit({
 
 ### excludeWalletIds
 
-Exclude wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet).
+Exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/).
 Array of wallet ids defined will be excluded. All other wallets will be shown in respective places.
 You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card.
 

--- a/docs/appkit/unity/core/options.mdx
+++ b/docs/appkit/unity/core/options.mdx
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem'
 
 ### Explorer included wallets
 
-Allows to set included wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to set included wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define a list of wallets ids you'd like to prioritize (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```csharp
 await AppKit.InitializeAsync(new AppKitConfig
@@ -19,7 +19,7 @@ await AppKit.InitializeAsync(new AppKitConfig
 
 ### Explorer excluded wallets
 
-Allows to set excluded wallets that are fetched from [WalletConnect Explorer](https://walletconnect.com/explorer?type=wallet). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
+Allows to set excluded wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can get these ids from the explorer link mentioned before by clicking on a copy icon of your desired wallet card.
 
 ```csharp
 await AppKit.InitializeAsync(new AppKitConfig

--- a/docs/cloud/chains/chain-list.mdx
+++ b/docs/cloud/chains/chain-list.mdx
@@ -4,7 +4,7 @@ import List from '../../components/List.js'
 
 ## Overview
 
-This page provides a list of chains on the [WalletConnect Explorer](https://explorer.walletconnect.com/). WalletConnect Explorer is a tool that allows users to discover wallets and dapps that support their preferred blockchain.
+This page provides a list of chains on the [WalletGuide](https://walletguide.walletconnect.network/). WalletGuide is a tool that allows users to discover wallets and dapps that support their preferred blockchain.
 
 On this page, you can:
 

--- a/docs/cloud/explorer-submission.mdx
+++ b/docs/cloud/explorer-submission.mdx
@@ -13,7 +13,7 @@ import PlatformTabItem from '../components/PlatformTabItem'
 :::info Note
 
 Submitting a project to the Reown Cloud Explorer is recommended but optional. You can still use Reown services without submitting your project.
-However, doing so ensures that your project is listed under [WalletConnect Explorer](https://walletconnect.com/explorer?utm_source=walletconnect-docs&utm_medium=cloud&utm_campaign=explorer-submission) and [Cloud Explorer API](./explorer.md).
+However, doing so ensures that your project is listed under [WalletGuide](https://walletguide.walletconnect.network/?utm_source=walletconnect-docs&utm_medium=cloud&utm_campaign=explorer-submission) and [Cloud Explorer API](./explorer.md).
 
 :::
 

--- a/docs/cloud/explorer.md
+++ b/docs/cloud/explorer.md
@@ -4,7 +4,7 @@ title: Explorer API
 
 The Cloud Explorer API currently offers the following functionality:
 
-- [Listings](#listings) - Allows for fetching of wallets and dApps listed in the [Reown Cloud Explorer](https://walletconnect.com/explorer).
+- [Listings](#listings) - Allows for fetching of wallets and dApps listed in the [WalletGuide](https://walletguide.walletconnect.network/).
 - [Logos](#logos) - Provides logo assets in different sizes for a given Cloud explorer entry.
 
 ### Listings
@@ -60,7 +60,7 @@ Examples:
 #### `GET /v3/all?projectId=YOUR_PROJECT_ID&ids=LISTING_ID1,LISTING_ID2`
 
 Returns a JSON object containing the entry listings by ID, which can be useful for allowlisting purposes. <br/>
-You can find and copy listing ids from our [Explorer](https://walletconnect.com/explorer)
+You can find and copy listing ids from our [WalletGuide](https://walletguide.walletconnect.network/)
 
 Examples:
 

--- a/docs/walletkit/ios/mobile-linking.mdx
+++ b/docs/walletkit/ios/mobile-linking.mdx
@@ -102,7 +102,7 @@ Dapps developers must do the same for their own custom schemes if they want the 
 
 ### iOS Wallet Support
 
-iOS has some more caveats to the integration but we ensure to make it as straightforward as possible. Since its operating system is not designed to handle multiple applications subscribing to the same deep linking schema, we've designed the AppKit to list supporting wallets on our [Explorer](https://walletconnect.com/explorer) and target specific deep links or universal links for each wallet.
+iOS has some more caveats to the integration but we ensure to make it as straightforward as possible. Since its operating system is not designed to handle multiple applications subscribing to the same deep linking schema, we've designed the AppKit to list supporting wallets on our [WalletGuide](https://walletguide.walletconnect.network/) and target specific deep links or universal links for each wallet.
 
 To add your own wallet to the Explorer, login to your [Reown Cloud](https://cloud.reown.com/sign-in) account.
 

--- a/docs/web3modal/v2/_partials/customisation/customExplorerWallets.mdx
+++ b/docs/web3modal/v2/_partials/customisation/customExplorerWallets.mdx
@@ -1,6 +1,6 @@
 You can manage wallets fetched from explorer via `explorerRecommendedWalletIds` and `explorerExcludedWalletIds` options to prioritize, include or exclude them.
 To fully disable explorer wallets, use `enableExplorer` options.
 
-You can get all wallet id's from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet) (click copy icon on chosen wallets).
+You can get all wallet id's from [WalletGuide](https://walletguide.walletconnect.network/) (click copy icon on chosen wallets).
 
 Below is an example of how to prioritize MetaMask, Rainbow and TrustWallet in that specific order:

--- a/docs/web3modal/v2/_partials/customisation/customManualWallets.mdx
+++ b/docs/web3modal/v2/_partials/customisation/customManualWallets.mdx
@@ -1,2 +1,2 @@
-If your WalletConnect enabled wallet is not present in [WalletConnect explorer](https://walletconnect.com/explorer) or is still pending approval,
+If your WalletConnect enabled wallet is not present in [WalletGuide](https://walletguide.walletconnect.network/) or is still pending approval,
 you can add it manually via `mobileWallets` and `desktopWallets` options.

--- a/docs/web3modal/v2/_partials/customisation/customWagmiWalletsIntro.mdx
+++ b/docs/web3modal/v2/_partials/customisation/customWagmiWalletsIntro.mdx
@@ -1,4 +1,4 @@
-AppKit includes wallets from 3 sources: [WalletConnect explorer](https://walletconnect.com/explorer), wagmi connectors and manually defined wallets.
+AppKit includes wallets from 3 sources: [WalletGuide](https://walletguide.walletconnect.network/), wagmi connectors and manually defined wallets.
 Below are defaults for each source:
 
 1. All WalletConnect explorer wallets that satisfy your options

--- a/docs/web3modal/v2/_partials/options/enableExplorer.mdx
+++ b/docs/web3modal/v2/_partials/options/enableExplorer.mdx
@@ -1,4 +1,4 @@
-Option to enable or disable wallet fetching from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet). Defaults to `true`.
+Option to enable or disable wallet fetching from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `true`.
 
 ```ts
 enableExplorer: false

--- a/docs/web3modal/v2/_partials/options/explorerExcludedWalletIds.mdx
+++ b/docs/web3modal/v2/_partials/options/explorerExcludedWalletIds.mdx
@@ -1,4 +1,4 @@
-Allows to exclude wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to exclude all wallets, you can set this option to `ALL`, however if `explorerRecommendedWalletIds` were defined, they will still be fetched. Defaults to `undefined`.
+Allows to exclude wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to exclude. You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to exclude all wallets, you can set this option to `ALL`, however if `explorerRecommendedWalletIds` were defined, they will still be fetched. Defaults to `undefined`.
 
 ```ts
 explorerExcludedWalletIds: [

--- a/docs/web3modal/v2/_partials/options/explorerRecommendedWalletIds.mdx
+++ b/docs/web3modal/v2/_partials/options/explorerRecommendedWalletIds.mdx
@@ -1,4 +1,4 @@
-Allows to override default recommended wallets that are fetched from [WalletConnect explorer](https://walletconnect.com/explorer?type=wallet). You can define an array of wallet ids you'd like to prioritise (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to completely disable recommended wallets, you can set this option to `NONE`. Defaults to `undefined`.
+Allows to override default recommended wallets that are fetched from [WalletGuide](https://walletguide.walletconnect.network/). You can define an array of wallet ids you'd like to prioritise (order is respected). You can get these ids from the explorer link mentioned before by clicking on a copy icon of desired wallet card. If you want to completely disable recommended wallets, you can set this option to `NONE`. Defaults to `undefined`.
 
 ```ts
 explorerRecommendedWalletIds: [

--- a/docs/web3modal/v2/_partials/options/projectId.mdx
+++ b/docs/web3modal/v2/_partials/options/projectId.mdx
@@ -1,4 +1,4 @@
-Your project's unique identifier that can be obtained at [cloud.reown.com](https://cloud.reown.com). Enables following functionalities within AppKit: wallet and chain logos, optional WalletConnect RPC, support for all wallets from [WalletConnect explorer](https://walletconnect.com/explorer) and WalletConnect v2 support. Defaults to `undefined`.
+Your project's unique identifier that can be obtained at [cloud.reown.com](https://cloud.reown.com). Enables following functionalities within AppKit: wallet and chain logos, optional WalletConnect RPC, support for all wallets from [WalletGuide](https://walletguide.walletconnect.network/) and WalletConnect v2 support. Defaults to `undefined`.
 
 ```ts
 projectId: string

--- a/docs/web3modal/v2/_partials/options/walletImages.mdx
+++ b/docs/web3modal/v2/_partials/options/walletImages.mdx
@@ -1,4 +1,4 @@
-Array of wallet id's and their logo mappings. This will override default logos. Id's in this case can be: [WalletConnect explorer](https://walletconnect.com/explorer) id's, wallet id's you provided in `mobileWallets` or `desktopWallets` and [wagmi](https://wagmi.sh) connector id's. Defaults to `undefined`.
+Array of wallet id's and their logo mappings. This will override default logos. Id's in this case can be: [WalletGuide](https://walletguide.walletconnect.network/) id's, wallet id's you provided in `mobileWallets` or `desktopWallets` and [wagmi](https://wagmi.sh) connector id's. Defaults to `undefined`.
 
 ```ts
 walletImages: {


### PR DESCRIPTION
## Description

WalletConnect Explorer is being renamed as WalletGuide. This PR replaces all references to "WalletConnect Explorer" with "WalletGuide". 

## Tests

Tested locally with Docusaurus.

**Do not merge until November 10, 2024**