### PR TITLE
Feat: add two web examples for theming

### DIFF
--- a/docs/appkit/shared/theming.mdx
+++ b/docs/appkit/shared/theming.mdx
@@ -1,5 +1,9 @@
 import Table from '../../components/Table'
 
+You can fully customize the theme for the AppKit integration in your Web3 app. Here are some examples.
+- [**Wormfare**](https://dashboard.wormfare.com/purchase)
+- [**BeraPong**](https://berapong.com/)
+
 ## ThemeMode
 
 By default `themeMode` option will be set to user system settings 'light' or 'dark'. But you can override it like this:

--- a/docs/appkit/shared/theming.mdx
+++ b/docs/appkit/shared/theming.mdx
@@ -1,6 +1,6 @@
 import Table from '../../components/Table'
 
-You can fully customize the theme for the AppKit integration in your Web3 app. Here are some examples.
+The theme for the AppKit integration in your dApp can be fully customized. Below are some examples:
 - [**Wormfare**](https://dashboard.wormfare.com/purchase)
 - [**BeraPong**](https://berapong.com/)
 


### PR DESCRIPTION
- Add two web examples in theme section
https://reown-docs-git-feat-add-theme-examples-reown-com.vercel.app/appkit/react/core/theming