### PR TITLE
Docs Update: Updating Mobile linking docs to address a redirect edge case

### DIFF
--- a/docs/walletkit/android/mobile-linking.mdx
+++ b/docs/walletkit/android/mobile-linking.mdx
@@ -25,12 +25,23 @@ When integrating a wallet with a mobile application, it's essential to understan
 
 **Developers should prefer Deep Linking over Universal Linking.**
 
-In the case of Universal Linking, the user may be redirected to the browser, which may not be the desired behavior. Deep Linking ensures that the user is redirected to the app, providing a seamless experience.
+Universal Linking may redirect the user to a browser, which might not provide the intended user experience. Deep Linking ensures the user is taken directly to the app.
 
 :::
 
+### Key Behavior to Address
+In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+
+Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
+Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+
+#### Recommended Approach
+To avoid this behavior, wallets should:
+
+Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
+Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+
 The connection and sign request flows are similar across platforms.
-The next section provides a high-level overview of both flows.
 
 ### Connection Flow
 

--- a/docs/walletkit/android/mobile-linking.mdx
+++ b/docs/walletkit/android/mobile-linking.mdx
@@ -38,8 +38,7 @@ Opening an unrelated application if a QR code is scanned on a different device t
 #### Recommended Approach
 To avoid this behavior, wallets should:
 
-Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
-Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+- **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
 
 The connection and sign request flows are similar across platforms.
 

--- a/docs/walletkit/best-practices.mdx
+++ b/docs/walletkit/best-practices.mdx
@@ -512,10 +512,23 @@ When integrating a wallet with a mobile application, it's essential to understan
 
 :::tip
 
-**Developers should prefer Deep Linking over Universal Linking.**<br />
-In the case of Universal Linking, the user may be redirected to the browser, which may not be the desired behavior. Deep Linking ensures that the user is redirected to the app, providing a seamless experience.
+**Developers should prefer Deep Linking over Universal Linking.**
+
+Universal Linking may redirect the user to a browser, which might not provide the intended user experience. Deep Linking ensures the user is taken directly to the app.
 
 :::
+
+### Key Behavior to Address
+In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+
+Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
+Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+
+#### Recommended Approach
+To avoid this behavior, wallets should:
+
+Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
+Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
 
 ### Connection Flow
 

--- a/docs/walletkit/best-practices.mdx
+++ b/docs/walletkit/best-practices.mdx
@@ -527,8 +527,7 @@ Opening an unrelated application if a QR code is scanned on a different device t
 #### Recommended Approach
 To avoid this behavior, wallets should:
 
-Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
-Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+- **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
 
 ### Connection Flow
 

--- a/docs/walletkit/flutter/mobile-linking.mdx
+++ b/docs/walletkit/flutter/mobile-linking.mdx
@@ -27,12 +27,23 @@ When integrating a wallet with a mobile application, it's essential to understan
 
 **Developers should prefer Deep Linking over Universal Linking.**
 
-In the case of Universal Linking, the user may be redirected to the browser, which may not be the desired behavior. Deep Linking ensures that the user is redirected to the app, providing a seamless experience.
+Universal Linking may redirect the user to a browser, which might not provide the intended user experience. Deep Linking ensures the user is taken directly to the app.
 
 :::
 
+### Key Behavior to Address
+In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+
+Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
+Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+
+#### Recommended Approach
+To avoid this behavior, wallets should:
+
+Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
+Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+
 The connection and sign request flows are similar across platforms.
-The next section provides a high-level overview of both flows.
 
 ### Connection Flow
 

--- a/docs/walletkit/flutter/mobile-linking.mdx
+++ b/docs/walletkit/flutter/mobile-linking.mdx
@@ -40,8 +40,7 @@ Opening an unrelated application if a QR code is scanned on a different device t
 #### Recommended Approach
 To avoid this behavior, wallets should:
 
-Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
-Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+- **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
 
 The connection and sign request flows are similar across platforms.
 

--- a/docs/walletkit/ios/mobile-linking.mdx
+++ b/docs/walletkit/ios/mobile-linking.mdx
@@ -25,12 +25,23 @@ When integrating a wallet with a mobile application, it's essential to understan
 
 **Developers should prefer Deep Linking over Universal Linking.**
 
-In the case of Universal Linking, the user may be redirected to the browser, which may not be the desired behavior. Deep Linking ensures that the user is redirected to the app, providing a seamless experience.
+Universal Linking may redirect the user to a browser, which might not provide the intended user experience. Deep Linking ensures the user is taken directly to the app.
 
 :::
 
+### Key Behavior to Address
+In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+
+Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
+Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+
+#### Recommended Approach
+To avoid this behavior, wallets should:
+
+Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
+Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+
 The connection and sign request flows are similar across platforms.
-The next section provides a high-level overview of both flows.
 
 ### Connection Flow
 

--- a/docs/walletkit/ios/mobile-linking.mdx
+++ b/docs/walletkit/ios/mobile-linking.mdx
@@ -29,11 +29,10 @@ Universal Linking may redirect the user to a browser, which might not provide th
 
 :::
 
-### Key Behavior to Address
-In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+#### Recommended Approach
+To avoid this behavior, wallets should:
 
-Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
-Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+- **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
 
 #### Recommended Approach
 To avoid this behavior, wallets should:

--- a/docs/walletkit/react-native/mobile-linking.mdx
+++ b/docs/walletkit/react-native/mobile-linking.mdx
@@ -25,12 +25,23 @@ When integrating a wallet with a mobile application, it's essential to understan
 
 **Developers should prefer Deep Linking over Universal Linking.**
 
-In the case of Universal Linking, the user may be redirected to the browser, which may not be the desired behavior. Deep Linking ensures that the user is redirected to the app, providing a seamless experience.
+Universal Linking may redirect the user to a browser, which might not provide the intended user experience. Deep Linking ensures the user is taken directly to the app.
 
 :::
 
+### Key Behavior to Address
+In some scenarios, wallets use redirect metadata provided in session proposals to open applications. This can cause unintended behavior, such as:
+
+Redirecting to the wrong app when multiple apps share the same redirect metadata (e.g., a desktop and mobile version of the same Dapp).
+Opening an unrelated application if a QR code is scanned on a different device than where the wallet is installed.
+
+#### Recommended Approach
+To avoid this behavior, wallets should:
+
+Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
+Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+
 The connection and sign request flows are similar across platforms.
-The next section provides a high-level overview of both flows.
 
 ### Connection Flow
 

--- a/docs/walletkit/react-native/mobile-linking.mdx
+++ b/docs/walletkit/react-native/mobile-linking.mdx
@@ -38,8 +38,7 @@ Opening an unrelated application if a QR code is scanned on a different device t
 #### Recommended Approach
 To avoid this behavior, wallets should:
 
-Restrict Redirect Metadata to Deep Link Use Cases: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
-Ensure Unique Redirect URIs for Cross-Platform Apps: Cross-platform Dapps should use distinct redirect URIs for their mobile and desktop versions to avoid conflicts.
+- **Restrict Redirect Metadata to Deep Link Use Cases**: Redirect metadata should only be used when the session proposal is initiated through a deep link. QR code scans should not trigger app redirects using session proposal metadata.
 
 The connection and sign request flows are similar across platforms.
 


### PR DESCRIPTION
## Description

This PR addresses an issue reported by @skibitsky and @jakubuid with wallets redirecting to the QR code instead of the dapp. Linear ticket [here](https://linear.app/reown/issue/DR-346/clarify-wallet-redirect-behavior-in-documentation-for-qr-code-scanning)

## Tests

Tested locally with Docusaurus. 