### PR TITLE
Docs update: Adding a "Getting support" section with React Native monorepo

### DIFF
--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -120,6 +120,13 @@ AppKit has support for [Wagmi](https://wagmi.sh) and [Ethers](https://docs.ether
 
 </PlatformTabs>
 
+## Getting Support 🙋
+
+Reown is committed to delivering the best developer experience.
+
+If you have any questions, feature requests, or bug reports, feel free to open an issue on [GitHub](https://github.com/reown-com/appkit-react-native)!
+
+
 ## Enable Wallet Detection
 
 :::info Note


### PR DESCRIPTION
## Description

The current docs do not link to the React Native monorepo where developers can report issues. This PR addresses that. 

## Tests

Tested locally with Docusaurus. 