### PR TITLE
Add example to fix Wagmi SSR with Nextjs 15 and Turbopack

### DIFF
--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -207,6 +207,19 @@ const nextConfig = {
 }
 ```
 
+- For new nextjs [turbopack](https://nextjs.org/docs/architecture/turbopack) bundler add the following code in the `next.config.js` file as webpack not used
+
+```ts
+// Path: next.config.js
+const nextConfig = {
+  serverExternalPackages: [
+    'pino-pretty',
+    'lokijs',
+    'encoding'
+  ],
+}
+```
+
 - [Learn more about SSR with Wagmi](https://wagmi.sh/react/guides/ssr)
 
 ## Video Tutorial


### PR DESCRIPTION
Add example to fix Wagmi SSR with Nextjs 15 and Turbopack as webpack config ignored

This config helps to resolve my issue with CookieStorage for Wagmi I shared here https://github.com/reown-com/appkit/issues/2978#issuecomment-2501666095