### PR TITLE
headers() function from next/headers returns a Promise<ReadonlyHeaders>

### DIFF
--- a/docs/appkit/next/wagmi/about/implementation.mdx
+++ b/docs/appkit/next/wagmi/about/implementation.mdx
@@ -142,7 +142,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const cookies = headers().get('cookie')
+
+  const headersObj = await headers();
+  const cookies = headersObj().get('cookie')
 
   return (
     <html lang="en">


### PR DESCRIPTION


## Description

The error occurs because the headers() function from next/headers returns a ```Promise<ReadonlyHeaders>```, not the ```ReadonlyHeaders``` object directly. 

Correction:

You need to ```await``` the ```headers()``` call to retrieve the actual headers object.


## Tests

Without awaiting the headers() call:

![reown_err](https://github.com/user-attachments/assets/df04b614-ad0d-4155-bd75-caea81fb08e2)

With awaiting the headers() call:

![reown_fixed](https://github.com/user-attachments/assets/50db288d-f52c-4dac-91c6-3758c34ff481)

