### PR TITLE
Docs Update: Replacing the demo URL and fixing a recipe

### DIFF
--- a/docs/appkit/recipes/solana-send-transaction.mdx
+++ b/docs/appkit/recipes/solana-send-transaction.mdx
@@ -4,7 +4,7 @@ title: Send a Solana Transaction Using AppKit Web
 
 import GithubBox from '../../components/GithubBox'
 
-# How to Sign Messages, Send Transactions, and Get Balance in Solana using AppKit
+# How to Sign Messages, Send Transactions, and Get Balance on Solana using AppKit
 
 Learn how to use Reown AppKit for essential wallet functionalities such as signing messages, sending transactions, and retrieving wallet balances.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -128,14 +128,14 @@ const config = {
         },
         {
           label: 'Cloud Dashboard',
-          href: 'https://cloud.reown.com/?utm_source=website&utm_medium=docs&utm_campaign=docs',
+          href: 'https://cloud.reown.com/?utm_source=navbar&utm_medium=docs&utm_campaign=backlinks',
           position: 'right',
           className: 'header-cloud-link',
           'aria-label': 'Cloud'
         },
         {
           label: 'AppKit Demo',
-          href: 'https://appkit-lab.reown.com/?utm_source=website&utm_medium=docs&utm_campaign=docs',
+          href: 'https://demo.reown.com/?utm_source=navbar&utm_medium=docs&utm_campaign=backlinks',
           position: 'right',
           className: 'header-cloud-link',
           'aria-label': 'Cloud'

--- a/sidebars.js
+++ b/sidebars.js
@@ -281,7 +281,7 @@ module.exports = {
                 { type: 'doc', label: 'Build a Telegram Mini App', id: 'appkit/recipes/telegram-mini-app' },
                 { type: 'doc', label: 'Configure Virtual TestNets', id: 'appkit/recipes/tenderly-virtual-testnets'},      
                 { type: 'doc', label: 'EVM Transactions using Wagmi', id: 'appkit/recipes/wagmi-send-transaction'} ,   
-                { type: 'doc', label: 'EVM Transactions using Solana', id: 'appkit/recipes/solana-send-transaction'}    
+                { type: 'doc', label: 'Solana Transactions using AppKit', id: 'appkit/recipes/solana-send-transaction'}    
               ]
             },
             {


### PR DESCRIPTION
## Description

This PR updates the AppKit Demo button to point to the new Reown AppKit Demo instead of AppKit Lab. This PR also fixes a minor issue with a recipe showing up on the sidebar and corrects the grammar of the title for the recipe. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-change-demo-reown-com.vercel.app/
- https://reown-docs-git-change-demo-reown-com.vercel.app/appkit/recipes/solana-send-transaction
