### PR TITLE
fix: Remove unnecessary parentheses in header cookie access

### DIFF
--- a/docs/appkit/next/wagmi/about/implementation.mdx
+++ b/docs/appkit/next/wagmi/about/implementation.mdx
@@ -144,7 +144,7 @@ export default function RootLayout({
 }>) {
 
   const headersObj = await headers();
-  const cookies = headersObj().get('cookie')
+  const cookies = headersObj.get('cookie')
 
   return (
     <html lang="en">


### PR DESCRIPTION
## Description

Remove unecessary parentheses after headersObj when accessing the cookie using next headers. The correct syntax is headersObj.get('cookie') as headersObj is an object, not a function.

Corrects code example syntax in headers documentation.

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

Insert the Vercel preview URL for all the doc pages that you have made changes to.

<PREVIEW_URL_1>
[https://reown-docs-git-fork-matsfjeldstad-remove-unnec-c446c2-reown-com.vercel.app/](https://reown-docs-git-fork-matsfjeldstad-remove-unnec-c446c2-reown-com.vercel.app/)
