### PR TITLE
fix: url for a working example in Solana

### DIFF
--- a/docs/appkit/javascript/solana/about/programs.mdx
+++ b/docs/appkit/javascript/solana/about/programs.mdx
@@ -1,6 +1,6 @@
 [@Solana/web3.js](https://solana.com/docs/clients/javascript) library allows for seamless interaction with wallets and smart contracts on the Solana blockchain.
 
-For a practical example of how it works, you can refer to this [demo app](https://appkit-solana.vercel.app/).
+For a practical example of how it works, you can refer to our [lab dApp](https://appkit-lab.reown.com/library/solana/).
 
 ```js
 import {

--- a/docs/appkit/next/solana/about/programs.mdx
+++ b/docs/appkit/next/solana/about/programs.mdx
@@ -1,6 +1,6 @@
 [@Solana/web3.js](https://solana.com/docs/clients/javascript) library allows for seamless interaction with wallets and smart contracts on the Solana blockchain.
 
-For a practical example of how it works, you can refer to this [demo app](https://appkit-solana.vercel.app/).
+For a practical example of how it works, you can refer to our [lab dApp](https://appkit-lab.reown.com/library/solana/).
 
 ```tsx
 import {

--- a/docs/appkit/react/solana/about/programs.mdx
+++ b/docs/appkit/react/solana/about/programs.mdx
@@ -1,6 +1,6 @@
 [@Solana/web3.js](https://solana.com/docs/clients/javascript) library allows for seamless interaction with wallets and smart contracts on the Solana blockchain.
 
-For a practical example of how it works, you can refer to this [demo app](https://appkit-solana.vercel.app/).
+For a practical example of how it works, you can refer to our [lab dApp](https://appkit-lab.reown.com/library/solana/).
 
 ```tsx
 import {

--- a/docs/appkit/vue/solana/programs.mdx
+++ b/docs/appkit/vue/solana/programs.mdx
@@ -1,6 +1,6 @@
 [@Solana/web3.js](https://solana.com/docs/clients/javascript) library allows for seamless interaction with wallets and smart contracts on the Solana blockchain.
 
-For a practical example of how it works, you can refer to this [demo app](https://appkit-solana.vercel.app/).
+For a practical example of how it works, you can refer to our [lab dApp](https://appkit-lab.reown.com/library/solana/).
 
 ```tsx
 import { ref } from 'vue';


### PR DESCRIPTION
## Description

change Url for a working example in solana

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

https://reown-docs-git-fix-old-links-solana-reown-com.vercel.app/appkit/react/core/installation?platform=solana
