### PR TITLE
Update one-click-auth.mdx

### DIFF
--- a/docs/walletkit/android/one-click-auth.mdx
+++ b/docs/walletkit/android/one-click-auth.mdx
@@ -46,7 +46,7 @@ To interact with authentication requests, build authentication objects (Wallet.M
 Example:
 
 ```kotlin
-ooverride val onSessionAuthenticate: ((Wallet.Model.SessionAuthenticate, Wallet.Model.VerifyContext) -> Unit)
+override val onSessionAuthenticate: ((Wallet.Model.SessionAuthenticate, Wallet.Model.VerifyContext) -> Unit)
   get() = { sessionAuthenticate, verifyContext ->
   val auths = mutableListOf<Wallet.Model.Cacao>()
 
@@ -96,7 +96,7 @@ WalletKit.approveSessionAuthenticate(approveProposal,
 If the authentication request cannot be approved or if the user chooses to reject it, use the rejectSessionAuthenticate method.
 
 ```kotlin
-val rejectParams = Wallet.Params.rejectSessionAuthenticate(
+val rejectParams = Wallet.Params.RejectSessionAuthenticate(
     id = sessionAuthenticate.id,
     reason = "Reason"
 )


### PR DESCRIPTION
- [x] - Fixed double "o" in "override"
- [x] - Updated the wrong function name to reject One-Click Auth

## Fixs:
https://github.com/ecoin-finance/reown-docs/commit/4621716211de69a242a8252ac175a72a386e704a
