### PR TITLE
feat: Add link and image to wallet buttons

### DIFF
--- a/docs/appkit/next/core/components.mdx
+++ b/docs/appkit/next/core/components.mdx
@@ -13,7 +13,7 @@ import Table from '../../../components/Table'
 
 <img src="/assets/walletButtons.jpg" />
 
-Using the wallet button components, you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
+Using the wallet button components ([Demo in our Lab](https://appkit-lab.reown.com/library/wagmi-wallet-button/)), you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
 This component allows to customize dApps, enabling users to connect their wallets effortlessly, all without the need for the traditional modal.
 
 Follow these steps to use the component:

--- a/docs/appkit/next/core/hooks.mdx
+++ b/docs/appkit/next/core/hooks.mdx
@@ -143,7 +143,9 @@ export default Component(){
 
 ## useAppKitWallet
 
-Using the wallet button hooks, you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
+<img src="/assets/walletButtons.jpg" />
+
+Using the wallet button hooks ([Demo in our Lab](https://appkit-lab.reown.com/library/wagmi-wallet-button/)), you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
 This hook allows to customize dApps, enabling users to connect their wallets effortlessly, all without the need to open the traditional modal.
 Execute this command to install the library for use it:
 

--- a/docs/appkit/next/core/theming.mdx
+++ b/docs/appkit/next/core/theming.mdx
@@ -1,4 +1,5 @@
 import Theming from '../../shared/theming.mdx'
+import Button from '../../../components/button/index.js'
 
 # Theming
 

--- a/docs/appkit/next/core/theming.mdx
+++ b/docs/appkit/next/core/theming.mdx
@@ -10,3 +10,5 @@ Wallet buttons are components that allow users to connect their wallets to your 
 You can also call them directly using hooks. Please check the [components](/appkit/next/core/components#walletButtons) and [hooks](/appkit/next/core/hooks#useappkitwallet) documentation for more information.
 
 <img src="/assets/walletButtons.jpg" />
+<br /><br />
+<Button name="Try Wallet Buttons" url="https://appkit-lab.reown.com/library/wagmi-wallet-button/" />

--- a/docs/appkit/react/core/components.mdx
+++ b/docs/appkit/react/core/components.mdx
@@ -13,7 +13,7 @@ import Components from '../../shared/components.mdx'
 
 <img src="/assets/walletButtons.jpg" />
 
-Using the wallet button components, you can directly connect to the top 20 wallets, WalletConnect QR, and all the social logins. 
+Using the wallet button components ([Demo in our Lab](https://appkit-lab.reown.com/library/wagmi-wallet-button/)), you can directly connect to the top 20 wallets, WalletConnect QR, and all the social logins. 
 This component allows to customize dApps, enabling users to connect their wallets effortlessly, all without the need to open the traditional modal.
 
 Follow these steps to use the component:

--- a/docs/appkit/react/core/hooks.mdx
+++ b/docs/appkit/react/core/hooks.mdx
@@ -144,7 +144,9 @@ export default Component(){
 
 ## useAppKitWallet
 
-Using the wallet button hooks, you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
+<img src="/assets/walletButtons.jpg" />
+
+Using the wallet button hooks ([Demo in our Lab](https://appkit-lab.reown.com/library/wagmi-wallet-button/)), you can directly connect to the top 20 wallets, WalletConnect QR and also all the social logins. 
 This hook allows to customize dApps, enabling users to connect their wallets effortlessly, all without the need to open the traditional modal.
 Execute this command to install the library for use it:
 

--- a/docs/appkit/react/core/theming.mdx
+++ b/docs/appkit/react/core/theming.mdx
@@ -1,4 +1,5 @@
 import Theming from '../../shared/theming.mdx'
+import Button from '../../../components/button/index.js'
 
 # Theming
 
@@ -10,3 +11,5 @@ Wallet buttons are components that allow users to connect their wallets to your 
 You can also call them directly using hooks. Please check the [components](/appkit/react/core/components#walletButtons) and [hooks](/appkit/react/core/hooks#useappkitwallet) documentation for more information.
 
 <img src="/assets/walletButtons.jpg" />
+<br /><br />
+<Button name="Try Wallet Buttons" url="https://appkit-lab.reown.com/library/wagmi-wallet-button/" />


### PR DESCRIPTION
## Description

Add link and image to wallet buttons

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-feat-add-image-and-link-to-wallet-reown-com.vercel.app/appkit/react/core/hooks#useappkitwallet
- https://reown-docs-git-feat-add-image-and-link-to-wallet-reown-com.vercel.app/appkit/react/core/components#appkit-wallet-button--
- https://reown-docs-git-feat-add-image-and-link-to-wallet-reown-com.vercel.app/appkit/react/core/theming#wallet-buttons
