### PR TITLE
chore(siwx): add authentication name to SIWX

### DIFF
--- a/docs/appkit/features/siwx/default.mdx
+++ b/docs/appkit/features/siwx/default.mdx
@@ -1,5 +1,5 @@
 ---
-title: SIWX
+title: Authentication (SIWX)
 ---
 
 import SiwxIndex from '../../shared/siwx/index.mdx'

--- a/docs/appkit/shared/siwx/index.mdx
+++ b/docs/appkit/shared/siwx/index.mdx
@@ -1,3 +1,5 @@
+import Button from '../../../components/button/index.js'
+
 ## Introduction
 
 The **Sign In With X** feature enables decentralized applications (Dapps) to authenticate users seamlessly across multiple blockchain networks, such as Ethereum, Polygon or Solana. This feature allows developers using our SDK to implement authentication by having users sign a unique string message with their blockchain wallets. The **Sign In With X** feature is designed in accordance with the [CAIP-122](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-122.md) standard, which establishes a chain-agnostic framework for blockchain-based authentication and authorization on off-chain services.

--- a/docs/appkit/shared/siwx/index.mdx
+++ b/docs/appkit/shared/siwx/index.mdx
@@ -5,6 +5,9 @@ The **Sign In With X** feature enables decentralized applications (Dapps) to aut
 <img src="/assets/siwe-connect.gif" />
 <br />
 
+<Button name="Try Demo" url="https://appkit-lab.reown.com/library/siwx-default/" />
+<br/>
+
 ## Getting Started
 
 **SIWX** works as a plugin system for AppKit and you are going to add the plugin in the AppKit configuration. There are some ways to implement the **SIWX** feature:

--- a/sidebars.js
+++ b/sidebars.js
@@ -248,7 +248,7 @@ module.exports = {
                 },
                 {
                   type: 'doc',
-                  label: 'SIWX',
+                  label: 'Authentication (SIWX)',
                   id: 'appkit/features/siwx/default'
                 },
                 { type: 'doc', label: 'Sponsored Transactions', id:'appkit/features/sponsored-transactions'}


### PR DESCRIPTION
## Description

Adds a more user-friendly name to the SIWX title/sidebar.

## Tests

- [ ] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [ ] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

Insert the Vercel preview URL for all the doc pages that you have made changes to.

<PREVIEW_URL_1>
