### PR TITLE
Update implementation.mdx

### DIFF
--- a/docs/appkit/next/ethers5/implementation.mdx
+++ b/docs/appkit/next/ethers5/implementation.mdx
@@ -6,6 +6,7 @@ In this example we will create a new file called `context/appkit.tsx` outside ou
 ```tsx
 'use client'
 
+import { createContext } from 'react'
 import { createAppKit } from '@reown/appkit/react'
 import { Ethers5Adapter } from '@reown/appkit-adapter-ethers5'
 import { mainnet, arbitrum } from '@reown/appkit/networks'
@@ -22,7 +23,7 @@ const metadata = {
 }
 
 // 3. Create the AppKit instance
-createAppKit({
+const appkit = createAppKit({
   adapters: [new Ethers5Adapter()],
   metadata: metadata,
   networks: [mainnet, arbitrum],
@@ -32,10 +33,12 @@ createAppKit({
   }
 })
 
-export function AppKit() {
+const AppKitContext = createContext(appkit);
+
+export function AppKit({ children }: { children: React.ReactNode }) {
   return (
-    <YourApp /> //make sure you have configured the <appkit-button> inside
-  )
+    <AppKitContext.Provider value={appkit}>{children}</AppKitContext.Provider>
+  );
 }
 ```
 


### PR DESCRIPTION
Update the implementation to use providers for better code clarity.

## Description

I was going through the docs to use it with ethers library... But, the implementation code was pretty unclear about whether to use `Provider` here or not. The earlier code, just used the `createAppKit` function, and that's it, but it as I infered from other examples (wagmi, for instance), this value returned by the function needed to be stored as `appkit`, in the context. In the next code block, `AppKit` was clearly being imported the way a Provider is done, therefore it made sense to update the code to be more clear about using a `ContextProvider` here.

I went on to create a provider, and tried using it on my end, and it worked.

## Tests
I am a beginner, so I couldn't do the following tests as suggested by maintainers:
- [ ] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [ ] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.
