### PR TITLE
Docs Fix: Fixing broken light mode display for Recipe container

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1597,7 +1597,7 @@ article ul li:not([role='tab'])::before {
   position: relative; /* Ensure positioning consistency */
   width: 391px; /* Width from Figma */
   height: 96px; /* Height from Figma */
-  background: #252525; /* Background color from Figma */
+  background: var(--ifm-container-background-color); /* Background color from Figma */
   border-radius: 28px; /* Border radius from Figma */
   border: 1.5px solid var(--ifm-border-color); /* Add consistent border styling */
   color: white; /* Text color */


### PR DESCRIPTION
## Description

There was a minor css issue that broke how the recipe container appeared on light mode. This PR fixes that.

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-fix-theme-reown-com.vercel.app/