### PR TITLE
Docs Fix: Fixing typo and removing device default theme being enforced

### DIFF
--- a/docs/appkit/features/index.mdx
+++ b/docs/appkit/features/index.mdx
@@ -28,5 +28,5 @@ While AppKit offers a wide range of features, networks, and authentication metho
 |    Bitcoin     |<center>✅</center>        |<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|
 | ***Authentication*** |                     |                  |                   |                  |                   |                   |                  |                   |                   | 
 | Email & Social Login |<center>✅</center>  |<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|
-|  On Click Auth |<center>✅</center>        |<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|
+|  One-Click Auth |<center>✅</center>        |<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>✅</center>|
 |    SIWX        |<center>✅</center>        |<center>✅</center>|<center>✅</center>|<center>✅</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|<center>❌</center>|

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -226,7 +226,8 @@ const config = {
     colorMode: {
       defaultMode: 'dark',
       disableSwitch: true,
-      respectPrefersColorScheme: true
+      respectPrefersColorScheme: false
+      
     },
     prism: {
       darkTheme: darkCodeTheme,


### PR DESCRIPTION
## Description

This PR fixes a type on the Features doc page and also fixes the docs defaulting to the user's device's default theme.

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-fix-docs-reown-com.vercel.app/
