### PR TITLE
Add all the links to test dApps

### DIFF
--- a/docs/appkit/android/core/installation.mdx
+++ b/docs/appkit/android/core/installation.mdx
@@ -1,4 +1,6 @@
-# Installation
+import GithubBox from '../../../components/GithubBox'
+
+# Kotlin
 
 Kotlin implementation of AppKit for Android applications.
 
@@ -11,7 +13,7 @@ AppKit ![Maven Central](https://img.shields.io/maven-central/v/com.reown/appkit)
 - Android min SDK 23
 - Java 11
 
-### Installation
+## Installation
 
 root/build.gradle.kts:
 
@@ -31,3 +33,11 @@ implementation(platform("com.reown:android-bom:$BOM_VERSION"))
 implementation("com.reown:android-core")
 implementation("com.reown:appkit")
 ```
+
+## Example
+
+<GithubBox name="AppKit with Kotlin example" url="https://github.com/reown-com/reown-kotlin/tree/develop/sample/dapp" description="Check the Kotlin example" />
+
+## Test dApps
+
+- [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/4cf60e7b49f9265e)

--- a/docs/appkit/android/core/installation.mdx
+++ b/docs/appkit/android/core/installation.mdx
@@ -38,6 +38,8 @@ implementation("com.reown:appkit")
 
 <GithubBox name="AppKit with Kotlin example" url="https://github.com/reown-com/reown-kotlin/tree/develop/sample/dapp" description="Check the Kotlin example" />
 
-## Test dApps
+## Test Apps
+
+Want to see AppKit in action? Download our sample AppKit apps below and explore what it can do. Enjoy! 😊
 
 - [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/4cf60e7b49f9265e)

--- a/docs/appkit/flutter/core/installation.mdx
+++ b/docs/appkit/flutter/core/installation.mdx
@@ -185,7 +185,9 @@ Coinbase Wallet is enabled by default even if, in order to function properly, a 
 
 <GithubBox name="AppKit with Flutter example" url="https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit/example/modal" description="Check the Flutter example" />
 
-## Test dApps
+## Test Apps
+
+Want to see AppKit in action? Download our sample AppKit apps below and explore what it can do. Enjoy! 😊
 
 - [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/2c6573f6956fa7b5)
 - [iOS Build (Testflight)](https://testflight.apple.com/join/6aRJSllc)

--- a/docs/appkit/flutter/core/installation.mdx
+++ b/docs/appkit/flutter/core/installation.mdx
@@ -5,6 +5,7 @@ title: Installation
 import PlatformTabs from '../../../components/PlatformTabs'
 import PlatformTabItem from '../../../components/PlatformTabItem'
 import YoutubeEmbed from '../../../components/YoutubeEmbed'
+import GithubBox from '../../../components/GithubBox'
 
 # Flutter
 
@@ -180,3 +181,11 @@ Example:
 
 Coinbase Wallet is enabled by default even if, in order to function properly, a few steps has to be done as described in the previous section. However, if you don't want to include/support Coinbase Wallet on your app you just need to pass Coinbase Wallet id `fd20dc426fb37566d803205b19bbc1d4096b248ac04548e3cfb6b3a38bd033aa` to [excludedWalletIds](./options#excludedwalletids) options Array.
 
+## Example
+
+<GithubBox name="AppKit with Flutter example" url="https://github.com/reown-com/reown_flutter/tree/master/packages/reown_appkit/example/modal" description="Check the Flutter example" />
+
+## Test dApps
+
+- [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/2c6573f6956fa7b5)
+- [iOS Build (Testflight)](https://testflight.apple.com/join/6aRJSllc)

--- a/docs/appkit/ios/core/installation.mdx
+++ b/docs/appkit/ios/core/installation.mdx
@@ -70,6 +70,8 @@ pod 'reown-swift/ReownAppKit', :git => 'https://github.com/reown-com/reown-swift
 
 <GithubBox name="AppKit with Swift example" url="https://github.com/reown-com/reown-swift/tree/develop/Example/ExampleApp.xcodeproj" description="Check the Swift example" />
 
-## Test dApps
+## Test Apps
+
+Want to see AppKit in action? Download our sample AppKit apps below and explore what it can do. Enjoy! 😊
 
 - [iOS Build (Testflight)](https://testflight.apple.com/join/7S1GYcjC)

--- a/docs/appkit/ios/core/installation.mdx
+++ b/docs/appkit/ios/core/installation.mdx
@@ -1,7 +1,8 @@
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
+import GithubBox from '../../../components/GithubBox'
 
-# Installation
+# Swift
 
 <Tabs>
 <TabItem value="spm" label="SPM">
@@ -64,3 +65,11 @@ pod 'reown-swift/ReownAppKit', :git => 'https://github.com/reown-com/reown-swift
 
 </TabItem>
 </Tabs>
+
+## Example
+
+<GithubBox name="AppKit with Swift example" url="https://github.com/reown-com/reown-swift/tree/develop/Example/ExampleApp.xcodeproj" description="Check the Swift example" />
+
+## Test dApps
+
+- [iOS Build (Testflight)](https://testflight.apple.com/join/7S1GYcjC)

--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -428,6 +428,11 @@ Check <a href="https://mobilewalletprotocol.github.io/wallet-mobile-sdk/docs/cli
 
 </PlatformTabs>
 
+## Test dApps
+
+- [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/0297fbd3de8f1e3f)
+- [iOS Build (Testflight)](https://testflight.apple.com/join/YW2jD2s0)
+
 ## Tutorial
 
 <YoutubeEmbed videoId="R0edIW72fHo" />

--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -428,7 +428,9 @@ Check <a href="https://mobilewalletprotocol.github.io/wallet-mobile-sdk/docs/cli
 
 </PlatformTabs>
 
-## Test dApps
+## Test Apps
+
+Want to see AppKit in action? Download our sample AppKit apps below and explore what it can do. Enjoy! 😊
 
 - [Android Build (Firebase)](https://appdistribution.firebase.google.com/pub/i/0297fbd3de8f1e3f)
 - [iOS Build (Testflight)](https://testflight.apple.com/join/YW2jD2s0)


### PR DESCRIPTION
## Description

Add all the links to test dApps

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-chore-add-link-to-test-dapps-reown-com.vercel.app/appkit/react-native/core/installation
- https://reown-docs-git-chore-add-link-to-test-dapps-reown-com.vercel.app/appkit/flutter/core/installation
- https://reown-docs-git-chore-add-link-to-test-dapps-reown-com.vercel.app/appkit/android/core/installation
- https://reown-docs-git-chore-add-link-to-test-dapps-reown-com.vercel.app/appkit/ios/core/installation