### PR TITLE
DOCS: fix javascript trigger modal action example

### DIFF
--- a/docs/appkit/javascript/ethers/about/triggermodal.mdx
+++ b/docs/appkit/javascript/ethers/about/triggermodal.mdx
@@ -41,11 +41,9 @@ Let's first add two html button elements into our `index.html` file:
   </head>
   <body>
     <div id="app">
+      /* highlight-add-start */
       <button id="open-connect-modal">Open Modal</button>
       <button id="open-network-modal">Open Networks</button>
-      /* highlight-add-start */
-      <appkit-button></appkit-button>
-      <appkit-network-button></appkit-network-button>
       /* highlight-add-end */
     </div>
     <script type="module" src="main.js"></script>


### PR DESCRIPTION
## Description

In the deployed docs the ["ethers actions" example](https://docs.reown.com/appkit/javascript/core/installation?platform=ethers) threw me off, so I thought I'd just raise a quick PR for it.
- Moved the highlighting to the buttons that are to be added, and,
- removed the web-components from the markup

## Tests

Umm, so bit of a bummer here actually I couldn't run this repo locally and have raised an issue for it so cannot check both the things below, you can check out the issue [here](https://github.com/reown-com/reown-docs/issues/248) btw.
- [ ] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [ ] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

Umm, not sure if I can even trigger a preview XD

Oh and also, there wasn't any `Contributing.md` so I just raised the PR for `main`, lmk if there are any changes to be made to the branch or the PR, would be glad to do so.

P.S. Love the project, and happy to help! ❤️ 
