### PR TITLE
Docs Fix: Updating the supported chains list on the smart accounts doc page

### DIFF
--- a/docs/appkit/features/smart-accounts.mdx
+++ b/docs/appkit/features/smart-accounts.mdx
@@ -19,17 +19,7 @@ Smart Accounts are deployed alongside the first transaction. Until deployment, a
 
 ### Supported Networks
 
-Smart Accounts are available on the following networks:
-
-- Base Sepolia
-- BSC (Binance Smart Chain)
-- Fraximal
-- Linea
-- Mode
-- Optimism
-- Polygon
-- Polygon Mumbai
-- Sepolia
+**Smart Accounts are available on several EVM networks. You can view the complete list of supported networks [here](https://docs.pimlico.io/infra/platform/supported-chains).**
 
 ### User Eligibility
 


### PR DESCRIPTION
## Description

This PR updates the supported chains list on the smart accounts doc page.

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- [reown-docs-git-fix-smart-accounts-reown-com.vercel.app/appkit/features/smart-accounts](https://reown-docs-git-fix-smart-accounts-reown-com.vercel.app/appkit/features/smart-accounts)
