### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/docs/appkit/shared/notifications/frontend-integration/api/managing-subscription/react.mdx
+++ b/docs/appkit/shared/notifications/frontend-integration/api/managing-subscription/react.mdx
@@ -13,7 +13,7 @@ const { unsubscribe, isLoading: isUnsubscribing } = useUnsubscribe()
 // get subscription of current user to current dapp
 const { data: subscription, getSubscription } = useSubscription()
 
-// getSubscription can be used to get information about different dapps programatically
+// getSubscription can be used to get information about different dapps programmatically
 const subscriptionToSameDappFromDifferentAccount = getSubscription(differentAccount)
 const subscriptionToDifferentDappFromSameAccount = getSubscription(undefined, differentDappDomain)
 const subscriptionToDifferentDappFromDifferentAccount = getSubscription(

--- a/docs/appkit/shared/siwx/siwx-custom.mdx
+++ b/docs/appkit/shared/siwx/siwx-custom.mdx
@@ -66,7 +66,7 @@ export interface SIWXConfig {
    *
    * Constraints:
    * - This method MUST verify all the sessions before storing them in the storage;
-   * - This method MUST replace all the sessions in the storage with the new ones succesfully otherwise it MUST throw an error.
+   * - This method MUST replace all the sessions in the storage with the new ones successfully otherwise it MUST throw an error.
    *
    * @param sessions SIWXSession[]
    */

--- a/docs/walletkit/ios/experimental/chain-abstraction.mdx
+++ b/docs/walletkit/ios/experimental/chain-abstraction.mdx
@@ -103,7 +103,7 @@ case .success(let routeResponseSuccess):
     case .notRequired(let routeResponseNotRequired):
         // user does not need to move funds from other chains, sign and broadcast original transaction
     case .error(let routeResponseError):
-        // error has occured, respod with an error to a dapp
+        // error has occurred, respond with an error to a dapp
     }
 ```
 


### PR DESCRIPTION
## Description

fix some typos in comment

## Tests

- [ ] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [ ] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

Insert the Vercel preview URL for all the doc pages that you have made changes to.

<PREVIEW_URL_1>
