### PR TITLE
Adding steps to use CLI for React, Next and Vue

### DIFF
--- a/docs/appkit/javascript/core/installation.mdx
+++ b/docs/appkit/javascript/core/installation.mdx
@@ -21,6 +21,8 @@ import SolanaPrograms from '../solana/about/programs.mdx'
 import BitcoinImplementation from '../bitcoin/about/implementation.mdx'
 import BitcoinModal from '../bitcoin/about/triggermodal.mdx'
 
+import GithubBox from '../../../components/GithubBox'
+
 # JavaScript
 
 AppKit has support for [Wagmi](https://wagmi.sh/) and [Ethers v6](https://docs.ethers.org/v6/) on Ethereum, [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana and Bitcoin.
@@ -79,6 +81,7 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5", "ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
+<GithubBox name="wagmi Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/javascript/javascript-wagmi" description="Check the Javascript wagmi example"></GithubBox>
 
 <WagmiImplementation />
 
@@ -89,16 +92,19 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 </PlatformTabItem>
 <PlatformTabItem value="ethers">
+<GithubBox name="ethers Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/javascript/javascript-ethers" description="Check the Javascript ethers example"></GithubBox>
 
 <EthersImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="solana">
+<GithubBox name="Solana Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/javascript/javascript-solana" description="Check the Javascript Solana example"></GithubBox>
 
 <SolanaImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="bitcoin">
+<GithubBox name="Bitcoin Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/javascript/javascript-bitcoin" description="Check the Javascript Bitcoin example"></GithubBox>
 
 <BitcoinImplementation />
 

--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -23,6 +23,8 @@ import SolanaPrograms from '../solana/about/programs.mdx'
 import BitcoinImplementation from '../bitcoin/about/implementation.mdx'
 import BitcoinModal from '../bitcoin/about/triggermodal.mdx'
 
+import GithubBox from '../../../components/GithubBox'
+
 # Next.js
 
 AppKit has support for [Wagmi](https://wagmi.sh/) and [Ethers v6](https://docs.ethers.org/v6/) on Ethereum, [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana and Bitcoin.
@@ -107,6 +109,7 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
+<GithubBox name="wagmi Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/nextjs/next-wagmi-app-router" description="Check the Next wagmi example"></GithubBox>
 
 <WagmiImplementation />
 
@@ -117,17 +120,19 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 </PlatformTabItem>
 <PlatformTabItem value="ethers">
+<GithubBox name="ethers Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/nextjs/next-ethers-app-router" description="Check the Next ethers example"></GithubBox>
 
 <EthersImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="solana">
+<GithubBox name="Solana Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/nextjs/next-solana-app-router" description="Check the Next Solana example"></GithubBox>
 
 <SolanaImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="bitcoin">
-
+<GithubBox name="Bitcoin Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/nextjs/next-bitcoin-app-router" description="Check the Next Bitcoin example"></GithubBox>
 <BitcoinImplementation />
 
 </PlatformTabItem>

--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -36,6 +36,30 @@ These steps are specific to [Next.js](https://nextjs.org/) app router. For other
 
 **If you prefer referring to a video tutorial for this, please [click here](#video-tutorial).**
 
+### AppKit CLI
+
+Reown offers a dedicated CLI to set up a minimal version of AppKit in the easiest and quickest way possible.
+
+To do this, please run the command below. 
+
+```bash
+npx @reown/appkit-cli
+```
+
+After running the command, you will be prompted to confirm the installation of the CLI. Upon your confirmation, the CLI will request the following details:
+
+1. **Project Name**: Enter the name for your project.
+2. **Framework**: Select your preferred framework or library. Currently, you have three options: React, Next.js, and Vue.
+3. **Network-Specific libraries**: Choose whether you want to install Wagmi, Ethers, Solana, or Multichain (EVM + Solana).
+
+After providing the project name and selecting your preferences, the CLI will install a minimal example of AppKit with your preferred blockchain library. The example will be pre-configured with a `projectId` that will only work on `localhost`. 
+
+To fully configure your project, please obtain a `projectId` from the Reown Cloud Dashboard and update your project accordingly.
+
+**Refer to [this section](#cloud-configuration) for more information.**
+
+### Custom Installation
+
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
 

--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -34,6 +34,30 @@ Choose one of these to get started.
 
 **If you prefer referring to a video tutorial for this, please [click here](#video-tutorial).**
 
+### AppKit CLI
+
+Reown offers a dedicated CLI to set up a minimal version of AppKit in the easiest and quickest way possible.
+
+To do this, please run the command below. 
+
+```bash
+npx @reown/appkit-cli
+```
+
+After running the command, you will be prompted to confirm the installation of the CLI. Upon your confirmation, the CLI will request the following details:
+
+1. **Project Name**: Enter the name for your project.
+2. **Framework**: Select your preferred framework or library. Currently, you have three options: React, Next.js, and Vue.
+3. **Network-Specific libraries**: Choose whether you want to install Wagmi, Ethers, Solana, or Multichain (EVM + Solana).
+
+After providing the project name and selecting your preferences, the CLI will install a minimal example of AppKit with your preferred blockchain library. The example will be pre-configured with a `projectId` that will only work on `localhost`. 
+
+To fully configure your project, please obtain a `projectId` from the Reown Cloud Dashboard and update your project accordingly.
+
+**Refer to [this section](#cloud-configuration) for more information.**
+
+### Custom Installation
+
 :::warning
 If you are setting up your React app, please **do not use** `npx create-react-app`, as it has been deprecated. Using it may cause dependency issues. 
 Instead, please use [Vite](https://vitejs.dev/guide/#scaffolding-your-first-vite-project) to create your React app. You can set it up by running `npm create vite@latest`.

--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -111,30 +111,31 @@ Create a new project on reown Cloud at https://cloud.reown.com and obtain a new 
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
-<GithubBox name="wagmi Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/react-wagmi" description="Check the React wagmi example"></GithubBox>
+<GithubBox name="wagmi Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-wagmi" description="Check the React wagmi example"></GithubBox>
 
 <WagmiImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="ethers5">
-<GithubBox name="Ethers v5 Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/react-ethers5" description="Check the React ethers v5 example"></GithubBox>
+<GithubBox name="Ethers v5 Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-ethers5" description="Check the React ethers v5 example"></GithubBox>
 
 <Ethers5Implementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="ethers">
-<GithubBox name="Ethers Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/react-ethers" description="Check the React ethers example"></GithubBox>
+<GithubBox name="Ethers Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-ethers" description="Check the React ethers example"></GithubBox>
 
 <EthersImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="solana">
-<GithubBox name="Solana Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/react-solana" description="Check the React Solana example"></GithubBox>
+<GithubBox name="Solana Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-solana" description="Check the React Solana example"></GithubBox>
 
 <SolanaImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="bitcoin">
+<GithubBox name="Bitcoin Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-bitcoin" description="Check the React Bitcoin example"></GithubBox>
 
 <BitcoinImplementation />
 

--- a/docs/appkit/vue/core/installation.mdx
+++ b/docs/appkit/vue/core/installation.mdx
@@ -102,7 +102,7 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
-<GithubBox name="wagmi Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/vue-wagmi" description="Check the Vue wagmi example"></GithubBox>
+<GithubBox name="wagmi Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/vue/vue-wagmi" description="Check the Vue wagmi example"></GithubBox>
 
 <WagmiImplementation />
 
@@ -113,16 +113,18 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 </PlatformTabItem>
 <PlatformTabItem value="ethers">
+<GithubBox name="ethers Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/vue/vue-ethers" description="Check the Vue ethers example"></GithubBox>
 
 <EthersImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="solana">
-<GithubBox name="Solana Example" url="https://github.com/reown-com/web-examples/tree/main/dapps/appkit/vue-solana" description="Check the Vue Solana example"></GithubBox>
+<GithubBox name="Solana Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/vue/vue-solana" description="Check the Vue Solana example"></GithubBox>
 <SolanaImplementation />
 
 </PlatformTabItem>
 <PlatformTabItem value="bitcoin">
+<GithubBox name="Bitcoin Example" url="https://github.com/reown-com/appkit-web-examples/tree/main/vue/vue-bitcoin" description="Check the Vue Bitcoin example"></GithubBox>
 
 <BitcoinImplementation />
 

--- a/docs/appkit/vue/core/installation.mdx
+++ b/docs/appkit/vue/core/installation.mdx
@@ -30,6 +30,30 @@ Choose one of these to get started.
 
 ## Installation
 
+### AppKit CLI
+
+Reown offers a dedicated CLI to set up a minimal version of AppKit in the easiest and quickest way possible.
+
+To do this, please run the command below. 
+
+```bash
+npx @reown/appkit-cli
+```
+
+After running the command, you will be prompted to confirm the installation of the CLI. Upon your confirmation, the CLI will request the following details:
+
+1. **Project Name**: Enter the name for your project.
+2. **Framework**: Select your preferred framework or library. Currently, you have three options: React, Next.js, and Vue.
+3. **Network-Specific libraries**: Choose whether you want to install Wagmi, Ethers, Solana, or Multichain (EVM + Solana).
+
+After providing the project name and selecting your preferences, the CLI will install a minimal example of AppKit with your preferred blockchain library. The example will be pre-configured with a `projectId` that will only work on `localhost`. 
+
+To fully configure your project, please obtain a `projectId` from the Reown Cloud Dashboard and update your project accordingly.
+
+**Refer to [this section](#cloud-configuration) for more information.**
+
+### Custom Installation
+
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 
 <PlatformTabItem value="wagmi">


### PR DESCRIPTION
## Description

This PR adds the steps to use the AppKit CLI to set up AppKit and install the necessary packages. This PR adds it to the installation doc page for React, Next and Vue. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- [React](https://reown-docs-git-add-cli-reown-com.vercel.app/appkit/react/core/installation#installation)
- [Next.js](https://reown-docs-git-add-cli-reown-com.vercel.app/appkit/next/core/installation#installation)
- [Vue](https://reown-docs-git-add-cli-reown-com.vercel.app/appkit/vue/core/installation#installation)
