### PR TITLE
fix: Removing Plausible and adding a utm_source for the Cloud banner

### DIFF
--- a/docs/components/CloudBanner.js
+++ b/docs/components/CloudBanner.js
@@ -3,21 +3,13 @@ import wcGlassImage from '../../static/assets/wc-logo-glass.png'
 import Link from '@docusaurus/Link'
 
 export const CloudBanner = props => {
-  const handleAnalytics = () => {
-    const props = {
-      path: window.location.pathname
-    }
-    plausible('cloud-banner-click', {
-      props
-    })
-  }
   return (
     <div className="cloud__wrapper">
       <div className="cloud__text-container">
         <h2>Don't have a project ID?</h2>
         <p>Head over to Reown Cloud and create a new project now!</p>
       </div>
-      <Link to="https://cloud.reown.com" target="_blank" onClick={handleAnalytics}>
+      <Link to="https://cloud.reown.com/?utm_source=cloud_banner&utm_medium=docs&utm_campaign=backlinks" target="_blank">
         Get started
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Description

The current configuration of the cloud banner uses Plausible to track clicks and other analytics. Since we no longer use Plausible, this PR removes that config and substitutes it with a utm_source instead. This will allow us to track analytics via Google Analytics. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-cloud-click-analytics-reown-com.vercel.app/appkit/react/core/installation#cloud-configuration
