### PR TITLE
feat: add Polkadot SDK JSON-RPC methods documentation

### DIFF
--- a/docs/advanced/multichain/rpc-reference/polkadot-sdk-rpc.md
+++ b/docs/advanced/multichain/rpc-reference/polkadot-sdk-rpc.md
@@ -1,0 +1,138 @@
+---
+description: Polkadot SDK JSON-RPC Methods
+---
+
+# Polkadot SDK
+
+## polkadot_signTransaction
+
+This method returns a signature for the provided transaction payload. It will be signed by the keypair corresponding to the requested signer address.
+
+### Parameters
+
+1. `Object` - Request parameters:
+   - `address`: `string` - SS58 encoded address of the signer
+   - `transactionPayload`: `Object` - As per Polkadot type `SignerPayloadJSON` containing:
+     - `address`: `string` - The SS58 encoded address (must match outer address)
+     - `assetId`: `HexString | null` - (optional) The id of the asset used to pay fees
+     - `blockHash`: `HexString` - The checkpoint hash of the block, 32 bytes
+     - `blockNumber`: `HexString` - The checkpoint block number (hex encoded)
+     - `era`: `HexString` - The mortality period of this transaction
+     - `genesisHash`: `HexString` - The genesis hash of the chain, 32 bytes
+     - `metadataHash`: `HexString | null` - (optional) The hash of the metadata for verification
+     - `method`: `string` - The SCALE encoded method data (hex encoded)
+     - `mode`: `number` - (optional) The mode for metadata verification (0=none, 1=exact, 2=partial)
+     - `nonce`: `HexString` - The nonce for this transaction (hex encoded)
+     - `specVersion`: `HexString` - The current specification version (hex encoded)
+     - `tip`: `HexString` - The tip for this transaction (hex encoded amount)
+     - `transactionVersion`: `HexString` - The current transaction version (hex encoded)
+     - `signedExtensions`: `string[]` - The array of signed extension identifiers
+     - `version`: `number` - The extrinsic version number
+     - `withSignedTransaction`: `boolean` - (optional) Request signed transaction bytes
+
+### Returns
+
+1. `Object` - Signature result:
+   - `signature`: `string` - hex encoded signature
+
+### Example
+
+```javascript
+// Request
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "polkadot_signTransaction",
+    "params": {
+        "address": "15UyNqZ7NB1QQVpY9xv7VGwkxtvXePKihFHx8kH4VgEcS1gU",
+        "transactionPayload": {
+            "address": "15UyNqZ7NB1QQVpY9xv7VGwkxtvXePKihFHx8kH4VgEcS1gU",
+            "assetId": null,
+            "blockHash": "0x1b1c32a33c3622044a3be1b7753ff9b24695c327fc9254f97c...",
+            "blockNumber": "0x00000393",
+            "era": "0x0500",
+            "genesisHash": "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+            "metadataHash": null,
+            "method": "0x0400....",
+            "mode": 0,
+            "nonce": "0x00000000",
+            "specVersion": "0x00000000",
+            "tip": "0x00000000000000000000000000000000",
+            "transactionVersion": "0x00000004",
+            "signedExtensions": [
+                "CheckNonZeroSender",
+                "CheckSpecVersion",
+                "CheckTxVersion",
+                "CheckGenesis",
+                "CheckMortality",
+                "CheckNonce",
+                "CheckWeight",
+                "ChargeTransactionPayment"
+            ],
+            "version": 4
+        }
+    }
+}
+
+// Result
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "signature": "0x01234567..."
+    }
+}
+```
+
+Note: The `method` field in the transaction payload contains the SCALE encoded call data specific to the transaction being signed. This typically includes the pallet name, function name and any parameters required for that specific transaction.
+
+## polkadot_signMessage
+
+This method returns a signature for the provided message payload. It will be signed by the keypair corresponding to the requested signer address.
+
+### Parameters
+
+1. `Object` - As per Polkadot type `SignerPayloadRaw` containing:
+   - `address`: `string` - SS58 encoded address
+   - `data`: `string` - The hex-encoded data for this request
+   - `type`: `'bytes' | 'payload'` - (optional) Identifies if the message is arbitrary bytes or a transaction payload
+
+:::note
+`polkadot_signMessage` can potentially be used to sign arbitrary transactions blindly. To mitigate this security risk:
+
+1. Always wrap messages in `<Bytes>message</Bytes>` tags before hex encoding when message `type` is `'bytes'` or not specified
+2. If the type is not `'payload'`, signers MUST verify that messages are properly wrapped
+3. Use `type: 'payload'` only when signing transaction-like data that should be possible to decrypt
+
+This convention helps prevent malicious applications from using `polkadot_signMessage` for blind transaction signing while maintaining compatibility with widely-used Polkadot signing implementations.
+:::
+
+### Returns
+
+1. `Object` - Signature result:
+   - `signature`: `string` - hex encoded signature
+
+### Example
+
+```javascript
+// Request
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "method": "polkadot_signMessage",
+    "params": {
+        "address": "15UyNqZ7NB1QQVpY9xv7VGwkxtvXePKihFHx8kH4VgEcS1gU",
+        "data": "0x3c42797465733e68656c6c6f20776f726c643c2f42797465733e", // "<Bytes>hello world</Bytes>" hex encoded
+        "type": "bytes"
+    }
+}
+
+// Result
+{
+    "id": 1,
+    "jsonrpc": "2.0",
+    "result": {
+        "signature": "0x6a98517e159dcaef1855cda5f5e5a61387ac3b63212b0f82642f5599502fc9eb1ea134e2db5dfbe0ec4530c6e7e576b177ad0618f68eaec37a3ac6dce819a30a"
+    }
+}
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -48,9 +48,10 @@ const advanced = {
           type: 'category',
           label: 'RPC Reference',
           items: [
-            'advanced/multichain/rpc-reference/cosmos-rpc',
             'advanced/multichain/rpc-reference/ethereum-rpc',
             'advanced/multichain/rpc-reference/solana-rpc',
+            'advanced/multichain/rpc-reference/polkadot-sdk-rpc',
+            'advanced/multichain/rpc-reference/cosmos-rpc',
             'advanced/multichain/rpc-reference/near-rpc',
             'advanced/multichain/rpc-reference/starknet-rpc',
             'advanced/multichain/rpc-reference/stellar-rpc',
@@ -235,7 +236,7 @@ module.exports = {
               label: 'Features',
               collapsed: false,
               collapsible: true,
-              link:{
+              link: {
                 type: 'doc',
                 id: 'appkit/features/index'
               },
@@ -250,7 +251,11 @@ module.exports = {
                   label: 'Telegram Mini Apps',
                   id: 'appkit/features/telegram-mini-apps'
                 },
-                { type: 'doc', label: 'Sponsored Transactions', id:'appkit/features/sponsored-transactions'}
+                {
+                  type: 'doc',
+                  label: 'Sponsored Transactions',
+                  id: 'appkit/features/sponsored-transactions'
+                }
               ]
             },
             {
@@ -271,28 +276,64 @@ module.exports = {
               collapsible: true,
               items: [
                 { type: 'doc', label: 'Email & Social Login', id: 'appkit/authentication/socials' },
-                { type: 'doc', label: 'One-Click Auth', id: 'appkit/authentication/one-click-auth' },
+                {
+                  type: 'doc',
+                  label: 'One-Click Auth',
+                  id: 'appkit/authentication/one-click-auth'
+                },
                 {
                   type: 'doc',
                   label: 'Sign in with X (SIWX)',
                   id: 'appkit/features/siwx/default'
-                },
+                }
               ]
             },
             {
               type: 'category',
               label: 'Recipes',
-              collapsed:true,
+              collapsed: true,
               collapsible: true,
               items: [
-                { type: 'doc', label: 'Build a Telegram Mini App', id: 'appkit/recipes/telegram-mini-app' },
-                { type: 'doc', label: 'Configure Virtual TestNets', id: 'appkit/recipes/tenderly-virtual-testnets'},    
-                { type: 'doc', label: 'EVM Transactions using Wagmi', id: 'appkit/recipes/wagmi-send-transaction'},
-                { type: 'doc', label: 'EVM Transactions using Ethers', id: 'appkit/recipes/ethers-send-transaction'},
-                { type: 'doc', label: 'Solana Transactions using AppKit', id: 'appkit/recipes/solana-send-transaction'},
-                { type: 'doc', label: 'Bitcoin Transactions using AppKit', id: 'appkit/recipes/bitcoin-send-transaction'},
-                { type: 'doc', label: 'Support Send Calls', id: 'appkit/recipes/switching-to-send-calls' },
-                { type: 'doc', label: 'Sponsoring Transaction with our Paymaster', id: 'appkit/recipes/sponsoring-first-transaction' } 
+                {
+                  type: 'doc',
+                  label: 'Build a Telegram Mini App',
+                  id: 'appkit/recipes/telegram-mini-app'
+                },
+                {
+                  type: 'doc',
+                  label: 'Configure Virtual TestNets',
+                  id: 'appkit/recipes/tenderly-virtual-testnets'
+                },
+                {
+                  type: 'doc',
+                  label: 'EVM Transactions using Wagmi',
+                  id: 'appkit/recipes/wagmi-send-transaction'
+                },
+                {
+                  type: 'doc',
+                  label: 'EVM Transactions using Ethers',
+                  id: 'appkit/recipes/ethers-send-transaction'
+                },
+                {
+                  type: 'doc',
+                  label: 'Solana Transactions using AppKit',
+                  id: 'appkit/recipes/solana-send-transaction'
+                },
+                {
+                  type: 'doc',
+                  label: 'Bitcoin Transactions using AppKit',
+                  id: 'appkit/recipes/bitcoin-send-transaction'
+                },
+                {
+                  type: 'doc',
+                  label: 'Support Send Calls',
+                  id: 'appkit/recipes/switching-to-send-calls'
+                },
+                {
+                  type: 'doc',
+                  label: 'Sponsoring Transaction with our Paymaster',
+                  id: 'appkit/recipes/sponsoring-first-transaction'
+                }
               ]
             },
             {
@@ -310,7 +351,7 @@ module.exports = {
               label: 'Migration',
               collapsed: true,
               collapsible: true,
-              link:{
+              link: {
                 type: 'doc',
                 id: 'appkit/migration/index'
               },
@@ -419,7 +460,11 @@ module.exports = {
         {
           type: 'category',
           label: 'Transactions',
-          items: ['appkit/react/transactions/onramp', 'appkit/react/transactions/swaps', 'appkit/react/transactions/sponsored-transactions']
+          items: [
+            'appkit/react/transactions/onramp',
+            'appkit/react/transactions/swaps',
+            'appkit/react/transactions/sponsored-transactions'
+          ]
         },
         {
           type: 'category',
@@ -518,7 +563,11 @@ module.exports = {
         {
           type: 'category',
           label: 'Transactions',
-          items: ['appkit/next/transactions/onramp', 'appkit/next/transactions/swaps', 'appkit/next/transactions/sponsored-transactions']
+          items: [
+            'appkit/next/transactions/onramp',
+            'appkit/next/transactions/swaps',
+            'appkit/next/transactions/sponsored-transactions'
+          ]
         },
         {
           type: 'category',
@@ -614,7 +663,11 @@ module.exports = {
         {
           type: 'category',
           label: 'Transactions',
-          items: ['appkit/vue/transactions/onramp', 'appkit/vue/transactions/swaps', 'appkit/vue/transactions/sponsored-transactions']
+          items: [
+            'appkit/vue/transactions/onramp',
+            'appkit/vue/transactions/swaps',
+            'appkit/vue/transactions/sponsored-transactions'
+          ]
         },
         {
           type: 'category',
@@ -710,7 +763,11 @@ module.exports = {
         {
           type: 'category',
           label: 'Transactions',
-          items: ['appkit/javascript/transactions/onramp', 'appkit/javascript/transactions/swaps', 'appkit/javascript/transactions/sponsored-transactions']
+          items: [
+            'appkit/javascript/transactions/onramp',
+            'appkit/javascript/transactions/swaps',
+            'appkit/javascript/transactions/sponsored-transactions'
+          ]
         },
         {
           type: 'category',


### PR DESCRIPTION
## Description

This PR adds a JSON-RPC reference for Polkadot SDK based chains. It includes two methods `polkadot_signTransaction` and `SignerPayloadRaw` and aligns with the polkadot examples https://docs.reown.com/advanced/multichain/polkadot/dapp-integration-guide

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

