### PR TITLE
Docs Update: Adding Upgrade guide to move from WalletConnect Modal to AppKit Basic

### DIFF
--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -12,7 +12,7 @@ This guide will show you how to upgrade to the most basic version of Reown AppKi
 
 ## AppKit Basic
 
-This is the easiest way for developers to go multi-chain. AppKit Basic utilies the `UniversalProvider` underneath and is a ready-to-use solution with hooks and methods.
+This is the easiest way for developers to go multi-chain. AppKit Basic utilizes the `UniversalProvider` underneath and is a ready-to-use solution with hooks and methods.
 
 <PlatformTabs
 	groupId="wcm"

--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -77,6 +77,15 @@ const modal = createAppKit({
 
 </PlatformTabs>
 
+### Examples
+
+Below are the examples for the corresponding library/programming language. 
+
+1. [HTML](https://github.com/reown-com/appkit/tree/main/examples/html-ak-basic)
+2. [React](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic)
+3. [NextJS](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-app-router)
+4. [Vue](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic)
+
 ## Ethereum Provider
 
 The Ethereum Provider implementation remains the same as before. Below is an example of how you can configure it:

--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -1,0 +1,78 @@
+---
+title: WalletConnect Modal to Reown AppKit Basic
+---
+import PlatformTabs from '../../components/PlatformTabs'
+import PlatformTabItem from '../../components/PlatformTabItem'
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+**WalletConnect Modal will soon be deprecated.** Consequently, projects and developers need to upgrade to Reown AppKit Basic. The most basic version of Reown AppKit will contain the traditional WalletConnect Modal with a QR code that users can scan and connect their wallets to. 
+
+This guide will show you how to upgrade to the most basic version of Reown AppKit.
+
+## AppKit Basic
+
+This is the easiest way for developers to go multi-chain. AppKit Basic utilies the `UniversalProvider` underneath and is a ready-to-use solution with hooks and methods.
+
+<PlatformTabs
+	groupId="wcm"
+	activeOptions={["react", "javascript", "vue"]}
+>
+<PlatformTabItem value="react">
+```javascript
+import { createAppKit } from '@reown/appkit/react'
+import { mainnet } from '@reown/appkit/networks'
+
+const modal = createAppKit({
+  adapters: [], //pass an empty array to only use WalletConnect QR
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+  networks: [mainnet]
+})
+```
+</PlatformTabItem>
+
+<PlatformTabItem value="javascript">
+```javascript
+import { createAppKit } from '@reown/appkit'
+import { mainnet } from '@reown/appkit/networks'
+
+const modal = createAppKit({
+  adapters: [], //pass an empty array to only use WalletConnect QR
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+  networks: [mainnet]
+})
+```
+</PlatformTabItem>
+
+<PlatformTabItem value="vue">
+```javascript
+import { createAppKit } from '@reown/appkit/vue'
+import { mainnet } from '@reown/appkit/networks'
+
+const modal = createAppKit({
+  adapters: [], //pass an empty array to only use WalletConnect QR
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+  networks: [mainnet]
+})
+```
+</PlatformTabItem>
+
+</PlatformTabs>

--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -292,3 +292,181 @@ Below are the examples for the corresponding library/programming language.
 2. [**React**](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic-up)
 3. [**NextJS**](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-up-app-router)
 4. [**Vue**](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic-up)
+
+## Sign Client with AppKit
+
+Below is how you can use `SignClient` with AppKit**.
+
+```javascript
+// Old Implementation
+/*highlight-delete-start*/
+import { SignClient } from '@walletconnect/sign-client'
+import { WalletConnectModal } from '@walletconnect/modal'
+
+
+const signClient = await SignClient.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+})
+
+const modal = new WalletConnectModal({
+  projectId: 'YOUR_PROJECT_ID',
+  chains: ['eip155:1']
+})
+
+// connect signClient and feed uri to modal
+const { uri, approval } = await signClient.connect({
+    requiredNamespaces: {
+      eip155: {
+        methods: [
+          'eth_sendTransaction',
+          'eth_signTransaction',
+          'eth_sign',
+          'personal_sign',
+          'eth_signTypedData'
+        ],
+        chains: ['eip155:1'],
+        events: ['chainChanged', 'accountsChanged']
+      }
+    }
+  })
+
+  if (uri) {
+    modal.openModal({ uri })
+    const session = await approval()
+    modal.closeModal()
+  }
+/*highlight-delete-end*/
+
+/*highlight-add-start*/
+
+// New Implementation
+
+import { SignClient } from '@walletconnect/sign-client'
+import { createAppKit) from '@reown/appkit'
+
+const signClient = await SignClient.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+})
+
+const modal = createAppKit({
+  projectId: 'YOUR_PROJECT_ID',
+  networks: [mainnet]
+})
+
+
+// connect signClient and feed uri to modal
+const { uri, approval } = await signClient.connect({
+    requiredNamespaces: {
+      eip155: {
+        methods: [
+          'eth_sendTransaction',
+          'eth_signTransaction',
+          'eth_sign',
+          'personal_sign',
+          'eth_signTypedData'
+        ],
+        chains: ['eip155:1'],
+        events: ['chainChanged', 'accountsChanged']
+      }
+    }
+  })
+
+  if (uri) {
+    modal.open({ uri, view: 'ConnectingWalletConnectBasic' })
+    const session = await approval()
+    modal.close()
+  }
+  /*highlight-add-end*/
+```
+
+### Changes
+
+For projects and developers that are currently using the `SignClient` with `WalletConnectModal` there is one option for you to upgrade. 
+
+#### Option 1
+
+Replace `WalletConnectModal` with AppKit. Below is what the implementation would look like. 
+
+```javascript
+// Old Code
+/*highlight-delete-start*/
+const modal = new WalletConnectModal({
+  projectId: 'YOUR_PROJECT_ID',
+  chains: ['eip155:1', 'solana:mainnet']
+})
+
+const { uri, approval } = await signClient.connect({
+    requiredNamespaces: {
+      eip155: {
+        methods: [
+          'eth_sendTransaction',
+          'eth_signTransaction',
+          'eth_sign',
+          'personal_sign',
+          'eth_signTypedData'
+        ],
+        chains: ['eip155:1'],
+        events: ['chainChanged', 'accountsChanged']
+      }
+    }
+  })
+
+  if (uri) {
+    modal.openModal({ uri })
+    const session = await approval()
+    modal.closeModal()
+  }
+/*highlight-delete-end*/
+
+// New Code
+/*highlight-add-start*/
+const modal = createAppKit({
+  projectId: 'YOUR_PROJECT_ID',
+  networks: [mainnet]
+})
+
+// connect signClient and feed uri to modal
+const { uri, approval } = await signClient.connect({
+    requiredNamespaces: {
+      eip155: {
+        methods: [
+          'eth_sendTransaction',
+          'eth_signTransaction',
+          'eth_sign',
+          'personal_sign',
+          'eth_signTypedData'
+        ],
+        chains: ['eip155:1'],
+        events: ['chainChanged', 'accountsChanged']
+      }
+    }
+  })
+
+  if (uri) {
+    modal.open({ uri, view: 'ConnectingWalletConnectBasic' })
+    const session = await approval()
+    modal.close()
+  }
+/*highlight-add-end*/
+```
+
+### Examples
+
+Below are the examples for the corresponding library/programming language. 
+
+1. [HTML](https://github.com/reown-com/appkit/tree/main/examples/html-ak-basic-sign-client)
+2. [React](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic-sign-client)
+3. [NextJS](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-sign-client-app-router)
+4. [Vue](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic-sign-client)

--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -8,7 +8,22 @@ import TabItem from '@theme/TabItem'
 
 **WalletConnect Modal will soon be deprecated.** Consequently, projects and developers need to upgrade to Reown AppKit Basic. The most basic version of Reown AppKit will contain the traditional WalletConnect Modal with a QR code that users can scan and connect their wallets to. 
 
-This guide will show you how to upgrade to the most basic version of Reown AppKit.
+<img src="/img/appkit-basic.gif" />
+
+This guide will show you how to upgrade to the most basic version of Reown AppKit. There are three different categories that this guide will be addressing, they are:
+
+1. [**AppKit Basic**](#appkit-basic)
+2. [**Ethereum Provider**](#ethereum-provider)
+3. [**Universal Provider with AppKit**](#universalprovider-with-appkit)
+4. [**Sign Client with AppKit**](#sign-client-with-appkit)
+
+## Installation
+
+You first need to install the AppKit package in order to get started. You can do this by running the command below.
+
+```bash npm2yarn
+npm install @reown/appkit
+```
 
 ## AppKit Basic
 
@@ -77,6 +92,8 @@ const modal = createAppKit({
 
 </PlatformTabs>
 
+You can also refer to the "Multichain" section under AppKit "Core" for installation. [Click here](/appkit/react/core/multichain?platform=basic) to learn more.
+
 ### Examples
 
 Below are the examples for the corresponding library/programming language. 
@@ -142,7 +159,7 @@ Here's how you can configure AppKit with `UniversalProvider`.
 // NEW IMPLEMENTATION
 
 import { UniversalProvider } from '@walletconnect/universal-provider'
-import { createAppKit) from '@reown/appkit'
+import { createAppKit } from '@reown/appkit'
 
 const provider = await UniversalProvider.init({
   projectId: 'YOUR_PROJECT_ID',
@@ -357,7 +374,7 @@ const { uri, approval } = await signClient.connect({
 // New Implementation
 
 import { SignClient } from '@walletconnect/sign-client'
-import { createAppKit) from '@reown/appkit'
+import { createAppKit } from '@reown/appkit'
 
 const signClient = await SignClient.init({
   projectId: 'YOUR_PROJECT_ID',

--- a/docs/appkit/upgrade/wcm.mdx
+++ b/docs/appkit/upgrade/wcm.mdx
@@ -76,3 +76,219 @@ const modal = createAppKit({
 </PlatformTabItem>
 
 </PlatformTabs>
+
+## Ethereum Provider
+
+The Ethereum Provider implementation remains the same as before. Below is an example of how you can configure it:
+
+```javascript
+import { EthereumProvider } from '@walletconnect/ethereum-provider'
+
+const provider = await EthereumProvider.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+  showQrModal: true,
+  optionalChains: [1, 137, 2020],
+
+  /*Optional - Add custom RPCs for each supported chain*/
+  rpcMap: {
+    1: 'mainnet.rpc...',
+    137: 'polygon.rpc...'
+  }
+})
+
+
+// Connect EthereumProvider, this will open modal
+await provider.connect()
+```
+
+### Changes Required
+
+Projects and developers don’t need to change anything in their configuration - upgrading the Ethereum Provider is sufficient. Projects will automatically receive the new QR modal UI.
+
+:::note
+Not all `themeVariables`will be compatible with the new UI, as `AppKit` uses a different design system than `walletConnectModal`
+:::
+
+### Examples
+
+Below are the examples for the corresponding library/programming language. 
+
+
+1. [**HTML**](https://github.com/reown-com/appkit/tree/main/examples/html-ep)
+2. [**React**](https://github.com/reown-com/appkit/tree/main/examples/react-ep)
+3. [**NextJS**](https://github.com/reown-com/appkit/tree/main/examples/next-ep-app-router)
+4. [**Vue**](https://github.com/reown-com/appkit/tree/main/examples/vue-ep)
+
+## UniversalProvider with AppKit 
+
+Here's how you can configure AppKit with `UniversalProvider`.
+
+```javascript
+// NEW IMPLEMENTATION
+
+import { UniversalProvider } from '@walletconnect/universal-provider'
+import { createAppKit) from '@reown/appkit'
+
+const provider = await UniversalProvider.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+})
+
+const modal = createAppKit({
+  projectId: 'YOUR_PROJECT_ID',
+  networks: [mainnet, solana]
+})
+
+
+// listen to display_uri event and feed modal with uri
+provider.on('display_uri', (uri: string) => {
+  modal.open({ uri, view: 'ConnectingWalletConnectBasic' })
+})
+
+// Connect provider, this will trigger display_uri event
+await provider.connect({
+  optionalNamespaces: {
+    eip155: {
+      methods: [
+        'eth_sendTransaction',
+        'eth_signTransaction',
+        'eth_sign',
+        'personal_sign',
+        'eth_signTypedData'
+      ],
+      chains: ['eip155:1'],
+      events: ['chainChanged', 'accountsChanged']
+    },
+    solana: {
+      methods: ['solana_signMessage', 'solana_signTransaction'],
+      chains: ['solana:mainnet'],
+      events: ['chainChanged', 'accountsChanged']
+    }
+  }
+})
+
+// OLD IMPLEMENTATION
+
+import { UniversalProvider } from '@walletconnect/universal-provider'
+import { WalletConnectModal } from '@walletconnect/modal'
+
+
+const provider = await UniversalProvider.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+})
+
+const modal = new WalletConnectModal({
+  projectId: 'YOUR_PROJECT_ID',
+  chains: ['eip155:1', 'solana:mainnet']
+})
+
+
+// listen to display_uri event and feed modal with uri
+provider.on('display_uri', (uri: string) => {
+  modal.openModal({ uri })
+})
+
+// Connect provider, this will trigger display_uri event
+await provider.connect({
+  optionalNamespaces: {
+    eip155: {
+      methods: [
+        'eth_sendTransaction',
+        'eth_signTransaction',
+        'eth_sign',
+        'personal_sign',
+        'eth_signTypedData'
+      ],
+      chains: ['eip155:1'],
+      events: ['chainChanged', 'accountsChanged']
+    },
+    solana: {
+      methods: ['solana_signMessage', 'solana_signTransaction'],
+      chains: ['solana:mainnet'],
+      events: ['chainChanged', 'accountsChanged']
+    }
+  }
+})
+```
+
+### Changes
+
+For projects that are currently using the `UniversalProvider` with `WalletConnectModal` there are two options for you to upgrade. 
+
+#### Option 1
+
+Upgrade to AppKit Basic and pass in the `UniversalProvider`. 
+
+```javascript
+const provider = await UniversalProvider.init({
+  projectId: 'YOUR_PROJECT_ID',
+  metadata: {
+    name: 'My Website',
+    description: 'My Website Description',
+    url: 'https://mywebsite.com', // origin must match your domain & subdomain
+    icons: ['https://avatars.githubusercontent.com/u/37784886']
+  },
+})
+
+const modal = createAppKit({
+  projectId: 'YOUR_PROJECT_ID',
+  networks: [mainnet, solana]
+  universalProvider: provider
+})
+```
+
+#### Option 2
+
+Replace `WalletConnectModal` with `AppKit`. 
+
+```javascript
+//Old Code
+/* highlight-delete-start */
+const modal = new WalletConnectModal({
+  projectId: 'YOUR_PROJECT_ID',
+  chains: ['eip155:1', 'solana:mainnet']
+})
+
+provider.on('display_uri', (uri: string) => {
+  modal.openModal({ uri })
+})
+/* highlight-delete-end */
+
+//New Code
+/* highlight-add-start */
+const modal = createAppKit({
+  projectId: 'YOUR_PROJECT_ID',
+  networks: [mainnet, solana]
+})
+
+provider.on('display_uri', (uri: string) => {
+  modal.open({ uri, view: 'ConnectingWalletConnectBasic' })
+})
+/* highlight-add-end */
+```
+
+### Examples
+
+Below are the examples for the corresponding library/programming language. 
+
+1. [**HTML**](https://github.com/reown-com/appkit/tree/main/examples/html-ak-basic-up)
+2. [**React**](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic-up)
+3. [**NextJS**](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-up-app-router)
+4. [**Vue**](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic-up)

--- a/sidebars.js
+++ b/sidebars.js
@@ -301,8 +301,8 @@ module.exports = {
               collapsed: true,
               collapsible: true,
               items: [
-                { type: 'doc', label: 'To Reown AppKit', id: 'appkit/upgrade/from-w3m-to-reown' }
-                //{ type: 'doc', label: 'AppKit v2 to v5', id: 'appkit/upgrade/appkitv2' },
+                { type: 'doc', label: 'Web3Modal to Reown AppKit', id: 'appkit/upgrade/from-w3m-to-reown' },
+                { type: 'doc', label: 'WalletConnect Modal to AppKit Basic', id: 'appkit/upgrade/wcm' }
               ]
             },
             {


### PR DESCRIPTION
## Description

This PR creates a consolidated upgrade guide on Web to move from WalletConnect Modal to AppKit Basic. It covers Ethereum Provider, Universal Provider and Sign Client as well. The PR also has examples to each web library/programming language that developers can refer to. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-wcm-upgrade-reown-com.vercel.app/appkit/upgrade/wcm
