### PR TITLE
Docs Update: Hiding wcm upgrade guide temporarily

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -302,7 +302,7 @@ module.exports = {
               collapsible: true,
               items: [
                 { type: 'doc', label: 'Web3Modal to Reown AppKit', id: 'appkit/upgrade/from-w3m-to-reown' },
-                { type: 'doc', label: 'WalletConnect Modal to AppKit Basic', id: 'appkit/upgrade/wcm' }
+                //{ type: 'doc', label: 'WalletConnect Modal to AppKit Basic', id: 'appkit/upgrade/wcm' }
               ]
             },
             {


### PR DESCRIPTION
## Description

This PR is to hide the WCM upgrade guide temporarily until AppKit Core is deployed. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-hide-wcm-upgrade-reown-com.vercel.app/