### PR TITLE
chore: added connectorImages prop to AppKit RN

### DIFF
--- a/docs/appkit/react-native/core/options.mdx
+++ b/docs/appkit/react-native/core/options.mdx
@@ -248,3 +248,17 @@ createAppKit({
   }
 })
 ```
+
+## connectorImages
+
+Set or override the images of any connector.
+
+```ts
+createAppKit({
+  connectorImages: {
+    coinbaseWallet: 'https://images.mydapp.com/coinbase.png',
+    walletConnect: 'https://images.mydapp.com/walletconnect.png',
+    appKitAuth: 'https://images.mydapp.com/auth.png',
+  }
+})
+```


### PR DESCRIPTION
## Description

Added new prop to override connector images

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s
https://reown-docs-git-chore-rn-connector-images-reown-com.vercel.app/appkit/react-native/core/options#connectorimages
