### PR TITLE
Docs Update: Updating Blockchain API limits for the free tier of AppKit

### DIFF
--- a/docs/cloud/blockchain-api.mdx
+++ b/docs/cloud/blockchain-api.mdx
@@ -27,7 +27,7 @@ No config or setup is needed for AppKit integrations. For other usage, see the [
 
 ## Limits
 
-The Blockchain API is free for 6 million requests per 30 days.
+The Blockchain API is free for 2.5 million requests per 30 days. If you wish to increase your limits, please contact sales@reown.com.
 
 ## Links
 


### PR DESCRIPTION
## Description

This PR updates the current Blockchain API limits mentioned in the docs for free tier. 

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-rpc-limits-reown-com.vercel.app/cloud/blockchain-api
