### PR TITLE
chore(config): update algolia appId, auto-recrawl via GHA

### DIFF
--- a/.github/workflows/algolia-reindex.yml
+++ b/.github/workflows/algolia-reindex.yml
@@ -1,0 +1,28 @@
+name: Algolia Docs Reindex
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  algolia_reindex:
+    runs-on: ubuntu-latest
+    name: Algolia Docs Reindex
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Algolia Crawler Reindex
+        uses: algolia/algoliasearch-crawler-github-actions@v1
+        with:
+          crawler-user-id: ${{ secrets.ALGOLIA_CRAWLER_USER_ID }}
+          crawler-api-key: ${{ secrets.ALGOLIA_CRAWLER_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          crawler-name: 'reown'
+          algolia-app-id: 'FNT2FF5Z1N'
+          algolia-api-key: ${{ secrets.ALGOLIA_API_KEY }}
+          site-url: 'https://docs.reown.com/'

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -58,7 +58,8 @@ const config = {
     }
   ],
   title: 'Reown Docs',
-  tagline: 'Reown gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.',
+  tagline:
+    'Reown gives developers the tools to build user experiences that make digital ownership effortless, intuitive, and secure.',
   url: 'https://docs.reown.com/',
   baseUrl: '/',
   onBrokenLinks: 'throw',
@@ -112,9 +113,9 @@ const config = {
   themeConfig: {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     algolia: {
-      appId: 'KEO8ND6AUT',
-      apiKey: '5921626237dc9040afc258af25d4e77d',
-      indexName: 'walletconnect',
+      appId: 'FNT2FF5Z1N',
+      apiKey: '858103ff345e1d20a487ee99ea8fa03a',
+      indexName: 'reown',
       contextualSearch: true
     },
     mermaid: {
@@ -227,7 +228,6 @@ const config = {
       defaultMode: 'dark',
       disableSwitch: true,
       respectPrefersColorScheme: false
-      
     },
     prism: {
       darkTheme: darkCodeTheme,


### PR DESCRIPTION
## Description

- Use updated Algolia appId and search apiKey with fresh index
- Sets up GHA to auto reindex the site when there is a change to `docs/**` on `main`

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

Insert the Vercel preview URL for all the doc pages that you have made changes to.

https://reown-docs-git-feat-algolia-auto-reindex-reown-com.vercel.app/
