### PR TITLE
Docs update: Replacing the AppKit demo on AppKit overview doc

### DIFF
--- a/docs/appkit/overview.mdx
+++ b/docs/appkit/overview.mdx
@@ -25,7 +25,7 @@ Reown AppKit is a powerful, free, and fully open-source solution for developers 
 Reown AppKit is open-source and free to use, which provides flexibility, transparency, and efficiency in building Web3 applications.
 
 ### Demo
-<Button name="Try Demo" url="https://appkit-lab.reown.com/" />
+<Button name="Try Demo" url="http://demo.reown.com/?utm_source=appkit&utm_medium=docs&utm_campaign=backlinks" />
 <br/>
 
 **Ready to get started? Check out the Quickstart section [here](#quickstart). Learn more about all the features AppKit offers [here](#features).**


### PR DESCRIPTION
## Description

This PR updates the the AppKit demo link on AppKit overview doc page.

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

- https://reown-docs-git-fix-appkit-demo-reown-com.vercel.app/appkit/overview
