### PR TITLE
feat: remove v19 warning

### DIFF
--- a/docs/appkit/next/core/components.mdx
+++ b/docs/appkit/next/core/components.mdx
@@ -6,16 +6,6 @@ import Components from '../../shared/components.mdx'
 import Table from '../../../components/Table'
 
 # Web Components
-:::warning
-If you are using React v19 and global components. Please add, before the component, the following directive to temporarily suppress TypeScript errors until the upgrade is fully supported:  
-
-```tsx
-{/* @ts-expect-error msg */}
-<appkit-button />
-```
-
-This will prevent TypeScript from reporting errors related to global component types.  
-:::
 <Components />
 
 ### `<appkit-wallet-button  />`

--- a/docs/appkit/next/core/installation.mdx
+++ b/docs/appkit/next/core/installation.mdx
@@ -140,16 +140,6 @@ Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new 
 
 ## Trigger the modal
 
-:::warning
-If you are using React v19 and global components. Please add, before the component, the following directive to temporarily suppress TypeScript errors until the upgrade is fully supported:  
-
-```tsx
-{/* @ts-expect-error msg */}
-<appkit-button />
-```
-
-This will prevent TypeScript from reporting errors related to global component types.  
-:::
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">
 

--- a/docs/appkit/react/core/components.mdx
+++ b/docs/appkit/react/core/components.mdx
@@ -8,16 +8,6 @@ import Components from '../../shared/components.mdx'
 # Web Components
 ## Trigger the modal
 
-:::warning
-If you are using React v19 and global components. Please add, before the component, the following directive to temporarily suppress TypeScript errors until the upgrade is fully supported:  
-
-```tsx
-{/* @ts-expect-error msg */}
-<appkit-button />
-```
-
-This will prevent TypeScript from reporting errors related to global component types.  
-:::
 <Components />
 
 ### `<appkit-wallet-button  />` 

--- a/docs/appkit/react/core/installation.mdx
+++ b/docs/appkit/react/core/installation.mdx
@@ -144,16 +144,6 @@ Create a new project on reown Cloud at https://cloud.reown.com and obtain a new 
 
 ## Trigger the modal
 
-:::warning
-If you are using React v19 and global components. Please add, before the component, the following directive to temporarily suppress TypeScript errors until the upgrade is fully supported:  
-
-```tsx
-{/* @ts-expect-error msg */}
-<appkit-button />
-```
-
-This will prevent TypeScript from reporting errors related to global component types.  
-:::
 
 <PlatformTabs groupId="eth-lib" activeOptions={["wagmi", "ethers5","ethers","solana","bitcoin"]}>
 <PlatformTabItem value="wagmi">


### PR DESCRIPTION
## Description

feat: remove v19 warning

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

https://reown-docs-git-feat-remove-react-v19-warn-reown-com.vercel.app/appkit/next/core/installation#trigger-the-modal
