### PR TITLE
Feat: add namespace to useAppKitAccount Hook

### DIFF
--- a/docs/appkit/next/core/hooks.mdx
+++ b/docs/appkit/next/core/hooks.mdx
@@ -40,9 +40,17 @@ Hook for accessing account data and connection status.
 ```ts
 import { useAppKitAccount } from "@reown/appkit/react";
 
-export default Component(){
-  const { address, isConnected, caipAddress, status, embeddedWalletInfo } = useAppKitAccount()
-}
+const { address, isConnected, caipAddress, status, embeddedWalletInfo } = useAppKitAccount()
+```
+
+Hook for accessing account data and connection status for each namespace when working in a multi-chain environment.
+
+```ts
+import { useAppKitAccount } from "@reown/appkit/react";
+
+const eip155Account = useAppKitAccount({ namespace: 'eip155' }) // for EVM chains
+const solanaAccount = useAppKitAccount({ namespace: 'solana' })
+const bip122Account = useAppKitAccount({ namespace: 'bip122' }) // for bitcoin
 ```
 
 ### Returns

--- a/docs/appkit/react/core/hooks.mdx
+++ b/docs/appkit/react/core/hooks.mdx
@@ -41,9 +41,17 @@ Hook for accessing account data and connection status.
 ```ts
 import { useAppKitAccount } from "@reown/appkit/react";
 
-export default Component(){
-  const { address, isConnected, caipAddress, status, embeddedWalletInfo } = useAppKitAccount()
-}
+const { address, isConnected, caipAddress, status, embeddedWalletInfo } = useAppKitAccount()
+```
+
+Hook for accessing account data and connection status for each namespace when working in a multi-chain environment.
+
+```ts
+import { useAppKitAccount } from "@reown/appkit/react";
+
+const eip155Account = useAppKitAccount({ namespace: 'eip155' }) // for EVM chains
+const solanaAccount = useAppKitAccount({ namespace: 'solana' })
+const bip122Account = useAppKitAccount({ namespace: 'bip122' }) // for bitcoin
 ```
 
 ### Returns

--- a/docs/appkit/vue/core/composables.mdx
+++ b/docs/appkit/vue/core/composables.mdx
@@ -40,9 +40,17 @@ Composable function for accessing account data and connection status.
 ```ts
 import { useAppKitAccount } from "@reown/appkit/vue";
 
-export default Component(){
-  const accountData = useAppKitAccount()
-}
+const accountData = useAppKitAccount()
+```
+
+Composable function for accessing account data and connection status for each namespace when working in a multi-chain environment.
+
+```ts
+import { useAppKitAccount } from "@reown/appkit/vue";
+
+const eip155Account = useAppKitAccount({ namespace: 'eip155' }) // for EVM chains
+const solanaAccount = useAppKitAccount({ namespace: 'solana' })
+const bip122Account = useAppKitAccount({ namespace: 'bip122' }) // for bitcoin
 ```
 
 ### Returns


### PR DESCRIPTION
## Description

add namespace to useAppKitAccount Hook

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

https://reown-docs-git-chore-add-useappkitaccount-name-7e28e2-reown-com.vercel.app/appkit/react/core/hooks#useappkitaccount
