### PR TITLE
feat: sets up llms.txt and llms-full.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 .docusaurus
 .cache-loader
 
+# LLMSTXT files
+/static/llms*.txt
+
 # Misc
 .DS_Store
 .env.local

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "docusaurus start",
     "spell": "cspell '**/*.md' '**/*.mdx' ",
     "start": " pnpm run spell && docusaurus start",
-    "build": "docusaurus build",
+    "build": "pnpm run build-llmstxt && docusaurus build",
+    "build-llmstxt": "cd scripts && node --experimental-json-modules build-llmstxt.js",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -43,9 +44,15 @@
     "@docusaurus/tsconfig": "^3.4.0",
     "@docusaurus/types": "^3.4.0",
     "cspell": "^8.16.1",
+    "gray-matter": "^4.0.3",
     "prettier": "3.2.2",
+    "remark-frontmatter": "^5.0.0",
+    "remark-mdx": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
     "typedoc-plugin-markdown": "3.17.1",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "unified": "^11.0.4"
   },
   "browserslist": {
     "production": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,15 +78,33 @@ importers:
       cspell:
         specifier: ^8.16.1
         version: 8.16.1
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       prettier:
         specifier: 3.2.2
         version: 3.2.2
+      remark-frontmatter:
+        specifier: ^5.0.0
+        version: 5.0.0
+      remark-mdx:
+        specifier: ^3.0.0
+        version: 3.0.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
       typedoc-plugin-markdown:
         specifier: 3.17.1
         version: 3.17.1(typedoc@0.25.13(typescript@5.3.3))
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      unified:
+        specifier: ^11.0.4
+        version: 11.0.4
 
 packages:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,15 +9,14 @@ The `build-llmstxt.js` script converts Docusaurus markdown files to LLMSTXT form
 ### Features
 
 - Converts all Markdown and MDX files in the `docs/` directory to plain text
-- Generates four output files:
+- Generates two output files:
   - `llms.txt`: Main index file with links to all documentation sections organized by directory and platform (Android, iOS, Flutter, React Native, etc.)
   - `llms-full.txt`: Contains all documentation
-  - `llms-appkit.txt`: Contains documentation from the `/appkit/` directory
-  - `llms-walletkit.txt`: Contains documentation from the `/walletkit/` directory
 - Preserves document structure and metadata
 - Follows the LLMSTXT 1.0 specification
 - Robust error handling with fallback for complex MDX files
 - Progress reporting during conversion
+- Properly handles index files by truncating `/index` segments in URLs to prevent 404 errors
 
 ### Setup
 
@@ -50,8 +49,6 @@ The script generates the following files in the `static/` directory:
 
 - `llms.txt`: Available at `docs.reown.com/llms.txt` - Main index with links to all documentation sections, organized by directory and platform
 - `llms-full.txt`: Available at `docs.reown.com/llms-full.txt` - Complete documentation
-- `llms-appkit.txt`: Available at `docs.reown.com/llms-appkit.txt` - AppKit documentation
-- `llms-walletkit.txt`: Available at `docs.reown.com/llms-walletkit.txt` - WalletKit documentation
 
 The files strictly follow the LLMSTXT spec format:
 
@@ -60,6 +57,7 @@ The files strictly follow the LLMSTXT spec format:
 3. Additional information about the project
 4. Sections delimited by H2 headers containing file lists
 5. Each file list entry includes a markdown hyperlink and description
+6. An "Optional" section as specified by the LLMSTXT spec for content that can be skipped if a shorter context is needed
 
 ### Dependencies
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,85 @@
+# Docusaurus Scripts
+
+This directory contains utility scripts for the Reown documentation site.
+
+## LLMSTXT Conversion Script
+
+The `build-llmstxt.js` script converts Docusaurus markdown files to LLMSTXT format according to the [LLMSTXT spec](https://llmstxt.org/).
+
+### Features
+
+- Converts all Markdown and MDX files in the `docs/` directory to plain text
+- Generates four output files:
+  - `llms.txt`: Main index file with links to all documentation sections organized by directory and platform (Android, iOS, Flutter, React Native, etc.)
+  - `llms-full.txt`: Contains all documentation
+  - `llms-appkit.txt`: Contains documentation from the `/appkit/` directory
+  - `llms-walletkit.txt`: Contains documentation from the `/walletkit/` directory
+- Preserves document structure and metadata
+- Follows the LLMSTXT 1.0 specification
+- Robust error handling with fallback for complex MDX files
+- Progress reporting during conversion
+
+### Setup
+
+The script uses ES modules, which are configured in the local `package.json` file in this directory. This allows the script to use modern JavaScript features without affecting the main Docusaurus project.
+
+### Usage
+
+You can run the script directly:
+
+```bash
+cd scripts
+node --experimental-json-modules build-llmstxt.js
+```
+
+Or use the npm script from the project root:
+
+```bash
+pnpm run build-llmstxt
+```
+
+To build the Docusaurus site and generate the LLMSTXT files in one command:
+
+```bash
+pnpm run build
+```
+
+### Output
+
+The script generates the following files in the `static/` directory:
+
+- `llms.txt`: Available at `docs.reown.com/llms.txt` - Main index with links to all documentation sections, organized by directory and platform
+- `llms-full.txt`: Available at `docs.reown.com/llms-full.txt` - Complete documentation
+- `llms-appkit.txt`: Available at `docs.reown.com/llms-appkit.txt` - AppKit documentation
+- `llms-walletkit.txt`: Available at `docs.reown.com/llms-walletkit.txt` - WalletKit documentation
+
+The files strictly follow the LLMSTXT spec format:
+
+1. An H1 with the name of the project or site
+2. A blockquote with a short summary
+3. Additional information about the project
+4. Sections delimited by H2 headers containing file lists
+5. Each file list entry includes a markdown hyperlink and description
+
+### Dependencies
+
+The script uses the following npm packages:
+
+- `unified`: Unified text processing interface
+- `remark-parse`: Markdown parser
+- `remark-mdx`: MDX parser
+- `remark-stringify`: Markdown serializer
+- `remark-frontmatter`: Frontmatter parser
+- `gray-matter`: Frontmatter extractor
+
+### Error Handling
+
+The script includes robust error handling:
+
+1. For standard Markdown files, it uses the full remark/unified pipeline
+2. For complex MDX files that can't be parsed by the standard pipeline, it falls back to a simpler regex-based extraction
+3. If a file can't be processed at all, it's skipped with an error message
+
+### CI/CD Integration
+
+The script is automatically run as part of the build process through the npm build script.

--- a/scripts/build-llmstxt.js
+++ b/scripts/build-llmstxt.js
@@ -84,6 +84,7 @@ async function processMarkdownFile(filePath) {
       const urlPath = relativePath
         .replace(/\\/g, '/') // Convert Windows path separators
         .replace(/\.(md|mdx)$/, '') // Remove file extension
+        .replace(/\/index$/, '') // Truncate '/index' segments to prevent 404 errors
 
       // Construct URL
       const url = `${SITE_URL}/${urlPath}`
@@ -118,6 +119,7 @@ async function processMarkdownFile(filePath) {
       const urlPath = relativePath
         .replace(/\\/g, '/') // Convert Windows path separators
         .replace(/\.(md|mdx)$/, '') // Remove file extension
+        .replace(/\/index$/, '') // Truncate '/index' segments to prevent 404 errors
 
       // Construct URL
       const url = `${SITE_URL}/${urlPath}`

--- a/scripts/build-llmstxt.js
+++ b/scripts/build-llmstxt.js
@@ -1,0 +1,448 @@
+/**
+ * Docusaurus-to-LLMSTXT Conversion Script
+ *
+ * This script converts Docusaurus markdown files to LLMSTXT format according to the
+ * LLMSTXT spec (https://llmstxt.org/). It generates two files:
+ * - llms.txt: Main index file with links to all documentation sections organized by directory and platform
+ * - llms-full.txt: Contains all documentation
+ *
+ * The index file (llms.txt) is organized by:
+ * 1. Top-level directories (Advanced, Api, Appkit, Cloud, Walletkit, Web3modal)
+ * 2. Platform subdivisions within each directory (Android, iOS, Flutter, React Native, etc.)
+ * 3. General sections for content not specific to any platform
+ *
+ * Files are generated in the static/ directory before the Docusaurus build process.
+ * The files strictly follow the LLMSTXT spec format:
+ * 1. An H1 with the name of the project or site
+ * 2. A blockquote with a short summary
+ * 3. Additional information about the project
+ * 4. Sections delimited by H2 headers containing file lists
+ * 5. Each file list entry includes a markdown hyperlink and description
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMdx from 'remark-mdx'
+import remarkStringify from 'remark-stringify'
+import remarkFrontmatter from 'remark-frontmatter'
+import grayMatter from 'gray-matter'
+
+// Get the directory name
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// Configuration
+const DOCS_DIR = path.join(__dirname, '..', 'docs')
+const OUTPUT_DIR = path.join(__dirname, '..', 'static')
+const SITE_URL = 'https://docs.reown.com'
+
+// Ensure output directory exists
+if (!fs.existsSync(OUTPUT_DIR)) {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true })
+}
+
+/**
+ * Process a markdown file and convert it to plain text
+ * @param {string} filePath - Path to the markdown file
+ * @returns {Object} - Object containing the processed content and metadata
+ */
+async function processMarkdownFile(filePath) {
+  try {
+    // Read the file content
+    const content = fs.readFileSync(filePath, 'utf8')
+
+    // Parse frontmatter
+    const { data: frontmatter, content: markdownContent } = grayMatter(content)
+
+    try {
+      // Process MDX/Markdown to plain text
+      const processor = unified()
+        .use(remarkParse)
+        .use(remarkMdx)
+        .use(remarkFrontmatter)
+        .use(remarkStringify, {
+          bullet: '-',
+          listItemIndent: 'one',
+          fences: true,
+          rule: '-'
+        })
+
+      const file = await processor.process(markdownContent)
+      let plainText = String(file)
+
+      // Clean up the text (remove HTML, simplify formatting)
+      plainText = plainText
+        .replace(/<[^>]*>/g, '') // Remove HTML tags
+        .replace(/\n\s*\n/g, '\n\n') // Normalize line breaks
+        .trim()
+
+      // Get relative path for URL construction
+      const relativePath = path.relative(DOCS_DIR, filePath)
+      const urlPath = relativePath
+        .replace(/\\/g, '/') // Convert Windows path separators
+        .replace(/\.(md|mdx)$/, '') // Remove file extension
+
+      // Construct URL
+      const url = `${SITE_URL}/${urlPath}`
+
+      // Get directory path relative to docs for categorization
+      const relativeDir = path.dirname(relativePath)
+
+      return {
+        title: frontmatter.title || path.basename(filePath, path.extname(filePath)),
+        url,
+        content: plainText,
+        path: relativePath,
+        directory: relativeDir
+      }
+    } catch (mdxError) {
+      // If MDX parsing fails, try a simpler approach for basic markdown
+      console.warn(`MDX parsing failed for ${filePath}, falling back to basic content extraction`)
+
+      // Extract title from frontmatter or filename
+      const title = frontmatter.title || path.basename(filePath, path.extname(filePath))
+
+      // Get basic content (strip out complex MDX syntax)
+      let basicContent = markdownContent
+        .replace(/import\s+.*?from\s+['"].*?['"]/g, '') // Remove import statements
+        .replace(/<.*?>/g, '') // Remove JSX/HTML tags
+        .replace(/\{.*?\}/g, '') // Remove JSX expressions
+        .replace(/\n\s*\n/g, '\n\n') // Normalize line breaks
+        .trim()
+
+      // Get relative path for URL construction
+      const relativePath = path.relative(DOCS_DIR, filePath)
+      const urlPath = relativePath
+        .replace(/\\/g, '/') // Convert Windows path separators
+        .replace(/\.(md|mdx)$/, '') // Remove file extension
+
+      // Construct URL
+      const url = `${SITE_URL}/${urlPath}`
+
+      // Get directory path relative to docs for categorization
+      const relativeDir = path.dirname(relativePath)
+
+      return {
+        title,
+        url,
+        content: basicContent,
+        path: relativePath,
+        directory: relativeDir
+      }
+    }
+  } catch (error) {
+    console.error(`Error processing file ${filePath}:`, error)
+    return null
+  }
+}
+
+/**
+ * Recursively find all markdown files in a directory
+ * @param {string} dir - Directory to search
+ * @param {Array} fileList - Accumulator for found files
+ * @returns {Array} - List of markdown file paths
+ */
+function findMarkdownFiles(dir, fileList = []) {
+  const files = fs.readdirSync(dir)
+
+  for (const file of files) {
+    const filePath = path.join(dir, file)
+    const stat = fs.statSync(filePath)
+
+    if (stat.isDirectory()) {
+      findMarkdownFiles(filePath, fileList)
+    } else if (/\.(md|mdx)$/.test(file)) {
+      fileList.push(filePath)
+    }
+  }
+
+  return fileList
+}
+
+/**
+ * Generate LLMSTXT content from processed markdown files
+ * @param {Array} processedFiles - List of processed markdown files
+ * @param {string} title - Title for the LLMSTXT file
+ * @param {string} description - Description for the LLMSTXT file
+ * @returns {string} - LLMSTXT formatted content
+ */
+function generateLLMSTXT(processedFiles, title, description) {
+  // LLMSTXT header - H1 with the name of the project or site
+  let llmstxt = `# ${title}\n\n`
+
+  // Blockquote with a short summary
+  llmstxt += `> ${description}\n\n`
+
+  // Additional information about the project
+  llmstxt += `This file contains documentation for the Reown platform, formatted according to the [LLMSTXT spec](https://llmstxt.org/).\n`
+  llmstxt += `Last updated: ${new Date().toISOString().split('T')[0]}\n\n`
+
+  // Add content from each processed file as a section with H2 header
+  for (const file of processedFiles) {
+    if (!file) continue
+
+    llmstxt += `## ${file.title}\n\n`
+    llmstxt += `- [${file.title}](${file.url}): Documentation for ${file.title}\n\n`
+    llmstxt += `${file.content}\n\n`
+  }
+
+  return llmstxt
+}
+
+/**
+ * Generate an index file in LLMSTXT format with links to documentation sections
+ * organized by directory and platform
+ * @param {Array} processedFiles - List of processed markdown files
+ * @returns {string} - LLMSTXT formatted index content with platform subdivisions
+ */
+function generateLLMSTXTIndex(processedFiles) {
+  // LLMSTXT header - H1 with the name of the project or site
+  let llmstxt = `# Reown Documentation\n\n`
+
+  // Blockquote with a short summary
+  llmstxt += `> Documentation for the Reown platform, a comprehensive toolkit for Web3 integration.\n\n`
+
+  // Additional information about the project
+  llmstxt += `Reown provides tools and SDKs for building Web3 applications and integrating wallets. `
+  llmstxt += `This index contains links to all documentation sections, organized by directory and platform.\n`
+  llmstxt += `Last updated: ${new Date().toISOString().split('T')[0]}\n\n`
+
+  // Get all top-level directories
+  const topDirs = fs.readdirSync(DOCS_DIR).filter(item => {
+    const itemPath = path.join(DOCS_DIR, item)
+    return fs.statSync(itemPath).isDirectory()
+  })
+
+  // Group files by top-level directory
+  const filesByDir = {}
+  for (const dir of topDirs) {
+    filesByDir[dir] = processedFiles.filter(
+      file => (file && file.directory.startsWith(dir)) || file.path.startsWith(dir)
+    )
+  }
+
+  // Platform directories to look for
+  const platformDirs = [
+    'android',
+    'ios',
+    'flutter',
+    'react-native',
+    'web',
+    'javascript',
+    'react',
+    'vue',
+    'next',
+    'unity',
+    'c-sharp'
+  ]
+
+  // Add links to each section
+  for (const dir of topDirs) {
+    const dirFiles = filesByDir[dir]
+    if (dirFiles.length === 0) continue
+
+    // Capitalize directory name for section title
+    const sectionTitle = dir.charAt(0).toUpperCase() + dir.slice(1)
+    llmstxt += `## ${sectionTitle}\n\n`
+
+    // Add description of the section based on the directory name
+    const sectionDescriptions = {
+      api: 'API reference documentation for the WalletConnect protocol.',
+      appkit: 'Documentation for AppKit, a toolkit for building applications with WalletConnect.',
+      walletkit:
+        'Documentation for WalletKit, a toolkit for integrating wallets with WalletConnect.',
+      cloud: 'Documentation for WalletConnect Cloud services and infrastructure.',
+      advanced: 'Advanced topics and guides for WalletConnect integration.',
+      web3modal: 'Documentation for Web3Modal, a UI component for connecting to wallets.',
+      components: 'Reusable components for WalletConnect integration.'
+    }
+
+    if (sectionDescriptions[dir]) {
+      llmstxt += `${sectionDescriptions[dir]}\n\n`
+    }
+
+    // Check if this directory has platform subdirectories
+    const dirPath = path.join(DOCS_DIR, dir)
+    let hasPlatformSubdirs = false
+
+    if (fs.existsSync(dirPath)) {
+      const subdirs = fs.readdirSync(dirPath).filter(item => {
+        const itemPath = path.join(dirPath, item)
+        return fs.statSync(itemPath).isDirectory()
+      })
+
+      // Check if any of the subdirectories are platform directories
+      hasPlatformSubdirs = subdirs.some(subdir => platformDirs.includes(subdir.toLowerCase()))
+    }
+
+    if (hasPlatformSubdirs) {
+      // Group files by platform
+      const filesByPlatform = {}
+      const otherFiles = []
+
+      for (const file of dirFiles) {
+        let foundPlatform = false
+
+        for (const platform of platformDirs) {
+          // Check if the file path contains the platform directory
+          if (
+            file.directory.includes(`/${platform}/`) ||
+            file.directory === platform ||
+            file.path.includes(`/${platform}/`) ||
+            file.path === platform
+          ) {
+            if (!filesByPlatform[platform]) {
+              filesByPlatform[platform] = []
+            }
+            filesByPlatform[platform].push(file)
+            foundPlatform = true
+            break
+          }
+        }
+
+        if (!foundPlatform) {
+          otherFiles.push(file)
+        }
+      }
+
+      // Add platform-specific sections
+      for (const platform of platformDirs) {
+        if (filesByPlatform[platform] && filesByPlatform[platform].length > 0) {
+          // Format platform name for display
+          let platformDisplay = platform
+          if (platform === 'ios') platformDisplay = 'iOS'
+          else if (platform === 'c-sharp') platformDisplay = 'C#'
+          else if (platform === 'javascript') platformDisplay = 'JavaScript'
+          else if (platform === 'react-native') platformDisplay = 'React Native'
+          else platformDisplay = platform.charAt(0).toUpperCase() + platform.slice(1)
+
+          llmstxt += `### ${platformDisplay}\n\n`
+
+          // Sort files by path for a more organized listing
+          const sortedFiles = [...filesByPlatform[platform]].sort((a, b) =>
+            a.path.localeCompare(b.path)
+          )
+
+          // Add links to files for this platform
+          for (const file of sortedFiles) {
+            llmstxt += `- [${file.title}](${file.url}): ${file.title} documentation for ${platformDisplay}\n`
+          }
+
+          llmstxt += '\n'
+        }
+      }
+
+      // Add other files that don't belong to a specific platform
+      if (otherFiles.length > 0) {
+        llmstxt += `### General\n\n`
+
+        // Sort files by path for a more organized listing
+        const sortedOtherFiles = [...otherFiles].sort((a, b) => a.path.localeCompare(b.path))
+
+        // Add links to other files
+        for (const file of sortedOtherFiles) {
+          llmstxt += `- [${file.title}](${file.url}): General documentation for ${file.title}\n`
+        }
+
+        llmstxt += '\n'
+      }
+    } else {
+      // No platform subdirectories, just list all files
+      // Sort files by path for a more organized listing
+      const sortedFiles = [...dirFiles].sort((a, b) => a.path.localeCompare(b.path))
+
+      // Add links to all files
+      for (const file of sortedFiles) {
+        llmstxt += `- [${file.title}](${file.url}): Documentation for ${file.title}\n`
+      }
+
+      llmstxt += '\n'
+    }
+  }
+
+  // Add a footer with links to specialized documentation files
+  llmstxt += `## Optional\n\n`
+  llmstxt += `These links contain more detailed or specialized documentation that can be skipped if a shorter context is needed:\n\n`
+  llmstxt += `- [Complete Documentation](${SITE_URL}/llms-full.txt): Full documentation for all Reown components\n\n`
+
+  return llmstxt
+}
+
+/**
+ * Main function to process all markdown files and generate LLMSTXT files
+ */
+async function main() {
+  try {
+    console.log('Starting Docusaurus-to-LLMSTXT conversion...')
+
+    // Find all markdown files
+    const markdownFiles = findMarkdownFiles(DOCS_DIR)
+    console.log(`Found ${markdownFiles.length} markdown files to process.`)
+
+    // Process all markdown files with progress tracking
+    let processedCount = 0
+    const totalFiles = markdownFiles.length
+
+    // Process files in batches to avoid overwhelming the system
+    const batchSize = 50
+    const processedFiles = []
+
+    for (let i = 0; i < markdownFiles.length; i += batchSize) {
+      const batch = markdownFiles.slice(i, i + batchSize)
+      const batchResults = await Promise.all(
+        batch.map(async file => {
+          const result = await processMarkdownFile(file)
+          processedCount++
+
+          // Log progress every 10% or for the last file
+          if (
+            processedCount % Math.max(1, Math.floor(totalFiles / 10)) === 0 ||
+            processedCount === totalFiles
+          ) {
+            const percentage = Math.floor((processedCount / totalFiles) * 100)
+            console.log(`Progress: ${processedCount}/${totalFiles} files (${percentage}%)`)
+          }
+
+          return result
+        })
+      )
+
+      processedFiles.push(...batchResults)
+    }
+
+    // Filter out null results (files that failed to process)
+    const validFiles = processedFiles.filter(file => file !== null)
+    console.log(`Successfully processed ${validFiles.length}/${totalFiles} files.`)
+
+    // Generate LLMSTXT files
+    console.log('Generating LLMSTXT files...')
+
+    // Generate full documentation file
+    const fullLLMSTXT = generateLLMSTXT(
+      validFiles,
+      'Reown Documentation',
+      'Complete documentation for Reown platform'
+    )
+
+    // Generate index file with platform subdivisions
+    const indexLLMSTXT = generateLLMSTXTIndex(validFiles)
+
+    // Write output files
+    console.log('Writing output files...')
+    fs.writeFileSync(path.join(OUTPUT_DIR, 'llms-full.txt'), fullLLMSTXT)
+    fs.writeFileSync(path.join(OUTPUT_DIR, 'llms.txt'), indexLLMSTXT)
+
+    console.log('LLMSTXT files generated successfully:')
+    console.log(`- ${path.join(OUTPUT_DIR, 'llms.txt')}`)
+    console.log(`- ${path.join(OUTPUT_DIR, 'llms-full.txt')}`)
+  } catch (error) {
+    console.error('Error generating LLMSTXT files:', error)
+    process.exit(1)
+  }
+}
+
+// Run the script
+main()

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "docusaurus-llmstxt-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "remark-frontmatter": "^5.0.0",
+    "remark-mdx": "^3.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-stringify": "^11.0.0",
+    "unified": "^11.0.4"
+  }
+}


### PR DESCRIPTION
## Overview
This PR implements support for the [LLMSTXT specification](https://llmstxt.org/) by generating two standardized text files (`llms.txt` and `llms-full.txt`) from our Docusaurus documentation. These files make our documentation more accessible to Large Language Models (LLMs) and other AI tools.

## Changes
- Added a new script (`scripts/build-llmstxt.js`) that converts Docusaurus markdown files to LLMSTXT format
- The script generates two files:
  - `llms.txt`: An index file with links to all documentation sections, organized by directory and platform
  - `llms-full.txt`: A comprehensive file containing all documentation content
- Added progress tracking and error handling for processing large numbers of files

## Implementation Details
- The script recursively processes all markdown and MDX files in the docs directory
- The script handles MDX parsing with fallback mechanisms for complex content
- Generated files are placed in the static directory for serving with the built site

## Benefits
- Improves documentation accessibility for AI tools and LLMs
- Enables more accurate and contextual responses from AI assistants when users ask about our documentation
- Follows the emerging LLMSTXT standard for better interoperability
- Maintains the existing documentation workflow while adding AI-friendly formats

## Next Steps
After merging, the `llms.txt` and `llms-full.txt` files will be available at:
- https://docs.reown.com/llms.txt
- https://docs.reown.com/llms-full.txt

At this point we can add them to `llms.txt` directories like:
* https://llmstxt.site/
* https://directory.llmstxt.cloud/


## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.
- [x] I've verified with a separate script that all the recursively generated URLs are valid

## Preview/s

Insert the Vercel preview URL for all the doc pages that you have made changes to.

https://reown-docs-git-feat-llms-txt-reown-com.vercel.app/llms.txt
https://reown-docs-git-feat-llms-txt-reown-com.vercel.app/llms-full.txt
