### PR TITLE
feat: change title of the guide in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -293,7 +293,7 @@ module.exports = {
                 { type: 'doc', label: 'Solana Transactions using AppKit', id: 'appkit/recipes/solana-send-transaction'},
                 { type: 'doc', label: 'Bitcoin Transactions using AppKit', id: 'appkit/recipes/bitcoin-send-transaction'},
                 { type: 'doc', label: 'Support Send Calls', id: 'appkit/recipes/switching-to-send-calls' },
-                { type: 'doc', label: 'Gas Sponsorship with Reown', id: 'appkit/recipes/sponsoring-first-transaction' },
+                { type: 'doc', label: 'Gas Sponsorship using AppKit', id: 'appkit/recipes/sponsoring-first-transaction' },
                 { type: 'doc', label: 'Travel Rule using AppKit', id: 'appkit/recipes/travel-rule'}
               ]
             },

--- a/sidebars.js
+++ b/sidebars.js
@@ -250,7 +250,7 @@ module.exports = {
                   label: 'Telegram Mini Apps',
                   id: 'appkit/features/telegram-mini-apps'
                 },
-                { type: 'doc', label: 'Sponsored Transactions', id:'appkit/features/sponsored-transactions'}
+                { type: 'doc', label: 'Gas Sponsorship', id:'appkit/features/sponsored-transactions'}
               ]
             },
             {
@@ -293,7 +293,7 @@ module.exports = {
                 { type: 'doc', label: 'Solana Transactions using AppKit', id: 'appkit/recipes/solana-send-transaction'},
                 { type: 'doc', label: 'Bitcoin Transactions using AppKit', id: 'appkit/recipes/bitcoin-send-transaction'},
                 { type: 'doc', label: 'Support Send Calls', id: 'appkit/recipes/switching-to-send-calls' },
-                { type: 'doc', label: 'Sponsoring Transaction with our Paymaster', id: 'appkit/recipes/sponsoring-first-transaction' },
+                { type: 'doc', label: 'Gas Sponsorship with Reown', id: 'appkit/recipes/sponsoring-first-transaction' },
                 { type: 'doc', label: 'Travel Rule using AppKit', id: 'appkit/recipes/travel-rule'}
               ]
             },


### PR DESCRIPTION
## Description

Change title of the guide in sidebar for Gas Sponsorship in two places

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s

https://reown-docs-git-feat-change-guide-title-sponsor-tx-reown-com.vercel.app/