### PR TITLE
[react-native] added note in coinbase integration

### DIFF
--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -294,8 +294,9 @@ module.exports = createRunOncePlugin(
 
 ## Enable Coinbase Wallet
 
-<Tabs groupId="platform">
-<TabItem value="rn-cli" label="React Native CLI">
+:::info Note
+Coinbase SDK uses `react-native-mmkv@2.x.x` internally, which makes the SDK not compatible with React Native's new architecture.
+:::
 
 Follow these steps to install Coinbase SDK in your project along with our Coinbase package. Check <a href="https://mobilewalletprotocol.github.io/wallet-mobile-sdk/docs/client-sdk/rn-install">here</a> for more detailed information.
 
@@ -310,7 +311,7 @@ npx install-expo-modules@latest
 2. Install Coinbase SDK
 
 ```
-yarn add @coinbase/wallet-mobile-sdk react-native-mmkv
+yarn add @coinbase/wallet-mobile-sdk react-native-mmkv@^2.0.0
 ```
 
 3. Install our custom connector
@@ -401,14 +402,6 @@ useEffect(() => {
 </PlatformTabs>
 
 Check <a href="https://mobilewalletprotocol.github.io/wallet-mobile-sdk/docs/client-sdk/rn-install">Coinbase docs</a> for more detailed information.
-
-</TabItem>
-
-<TabItem value="expo" label="Expo">
-  Coinbase SDK doesn't support Expo Projects. More info <a href="https://github.com/MobileWalletProtocol/wallet-mobile-sdk/issues/206#issuecomment-1468836345">here</a>
-</TabItem>
-
-</Tabs>
 
 ## Examples
 

--- a/docs/appkit/react-native/core/installation.mdx
+++ b/docs/appkit/react-native/core/installation.mdx
@@ -294,13 +294,15 @@ module.exports = createRunOncePlugin(
 
 ## Enable Coinbase Wallet
 
-:::info Note
-Coinbase SDK uses `react-native-mmkv@2.x.x` internally, which makes the SDK not compatible with React Native's new architecture.
-:::
+> ⚠️ **Important Compatibility Notice**
+> 
+> The Coinbase SDK currently has the following limitations:
+> - Does not support React Native's New Architecture
+> - Does not support Expo Go
+>
+> If you're using the New Architecture, you'll need to disable it for Coinbase SDK compatibility. For Expo users, a custom development build is required.
 
 Follow these steps to install Coinbase SDK in your project along with our Coinbase package. Check <a href="https://mobilewalletprotocol.github.io/wallet-mobile-sdk/docs/client-sdk/rn-install">here</a> for more detailed information.
-
-- Note: Coinbase SDK is [not compatible with Expo Go](https://github.com/MobileWalletProtocol/wallet-mobile-sdk/issues/206)
 
 1. Enable Expo Modules in your project running:
 


### PR DESCRIPTION
## Description
* Added note on Coinbase integration steps related to the new architecture
* Removed expo tab on Coinbase steps

## Tests

- [x] - Ran the changes locally with Docusaurus. and confirmed that the changes appear as expected.
- [x] - Applied the corrections suggested by Cspell on the `.mdx` files with changes.

## Preview/s
https://reown-docs-git-chore-rn-coinbase-reown-com.vercel.app/appkit/react-native/core/installation#enable-coinbase-wallet
