### PR TITLE
fix: standardize capitalization in AppKit dropdowns

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -260,9 +260,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - React",
+        "dropdown": "AppKit - React",
         "icon": "react",
-        "description": "Appkit on React",
+        "description": "AppKit on React",
         "groups": [
           {
             "group": "AppKit",
@@ -346,9 +346,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Next",
+        "dropdown": "AppKit - Next",
         "icon": "square-n",
-        "description": "Appkit on NextJS",
+        "description": "AppKit on NextJS",
         "groups": [
           {
             "group": "AppKit",
@@ -432,9 +432,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Vue",
+        "dropdown": "AppKit - Vue",
         "icon": "vuejs",
-        "description": "Appkit on VueJS",
+        "description": "AppKit on VueJS",
         "groups": [
           {
             "group": "AppKit",
@@ -515,9 +515,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Javascript",
+        "dropdown": "AppKit - Javascript",
         "icon": "js",
-        "description": "Appkit on Javascript",
+        "description": "AppKit on Javascript",
         "groups": [
           {
             "group": "AppKit",
@@ -598,9 +598,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - React Native",
+        "dropdown": "AppKit - React Native",
         "icon": "mobile-screen-button",
-        "description": "Appkit on React Native",
+        "description": "AppKit on React Native",
         "groups": [
           {
             "group": "AppKit",
@@ -666,9 +666,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Flutter",
+        "dropdown": "AppKit - Flutter",
         "icon": "flutter",
-        "description": "Appkit on Flutter",
+        "description": "AppKit on Flutter",
         "groups": [
           {
             "group": "AppKit",
@@ -707,9 +707,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Android",
+        "dropdown": "AppKit - Android",
         "icon": "android",
-        "description": "Appkit on Android",
+        "description": "AppKit on Android",
         "groups": [
           {
             "group": "AppKit",
@@ -745,9 +745,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - iOS",
+        "dropdown": "AppKit - iOS",
         "icon": "apple",
-        "description": "Appkit on iOS",
+        "description": "AppKit on iOS",
         "groups": [
           {
             "group": "AppKit",
@@ -782,9 +782,9 @@
         ]
       },
       {
-        "dropdown": "Appkit - Unity",
+        "dropdown": "AppKit - Unity",
         "icon": "unity",
-        "description": "Appkit on Unity",
+        "description": "AppKit on Unity",
         "groups": [
           {
             "group": "AppKit",


### PR DESCRIPTION
## Description

- Fix casing in sidebar/nav: `Appkit` -> `AppKit`

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.