### PR TITLE
Update tab title to match code snippet

### DIFF
--- a/snippets/appkit/shared/bitcoin-provider.mdx
+++ b/snippets/appkit/shared/bitcoin-provider.mdx
@@ -28,7 +28,7 @@ export interface BitcoinConnector extends ChainAdapterConnector, Provider {
   }
 ```
 </Tab>
-<Tab title="SignMessageParams">
+<Tab title="SendTransferParams">
 ```ts
   export type SendTransferParams = {
     /**


### PR DESCRIPTION
## Description

Hello 👋

While browsing the documentation, I noticed a small typo in the Bitcoin snippet section.

In the page https://docs.reown.com/appkit/javascript/core/installation, under the *Bitcoin Provider Interface* > *Parameters*, the code snippet for `SendTransferParams` has an incorrect tab title — it's labeled as `SignMessageParams`, which seems to be a copy-paste error (see attached screenshot).

This PR corrects the title so it matches the actual code.

Thanks in advance! 🙏

<img width="644" alt="image" src="https://github.com/user-attachments/assets/ebe0c901-d553-4575-826a-fa13cd8ff2ac" />
