### PR TITLE
refactor(docs): configure proper frontmatter titles

### DIFF
--- a/appkit/javascript/core/actions.mdx
+++ b/appkit/javascript/core/actions.mdx
@@ -6,8 +6,6 @@ import WagmiActions from "/snippets/appkit/javascript/wagmi/actions.mdx";
 import EthersActions from "/snippets/appkit/javascript/ethers/actions.mdx";
 import SolanaActions from "/snippets/appkit/javascript/solana/actions.mdx";
 
-# Actions
-
 Actions are functions that will help you control the modal, subscribe to wallet events and interact with them and smart contracts.
 
 ## Open and close the modal

--- a/appkit/javascript/core/actions.mdx
+++ b/appkit/javascript/core/actions.mdx
@@ -1,3 +1,7 @@
+---
+title: Actions
+---
+
 import WagmiActions from "/snippets/appkit/javascript/wagmi/actions.mdx";
 import EthersActions from "/snippets/appkit/javascript/ethers/actions.mdx";
 import SolanaActions from "/snippets/appkit/javascript/solana/actions.mdx";

--- a/appkit/javascript/core/custom-connectors.mdx
+++ b/appkit/javascript/core/custom-connectors.mdx
@@ -1,3 +1,7 @@
+---
+title: Custom connectors
+---
+
 # Custom connectors
 
 Add custom connectors for Ethers or Wagmi

--- a/appkit/javascript/core/custom-connectors.mdx
+++ b/appkit/javascript/core/custom-connectors.mdx
@@ -2,8 +2,6 @@
 title: Custom connectors
 ---
 
-# Custom connectors
-
 Add custom connectors for Ethers or Wagmi
 
 <Tabs>

--- a/appkit/javascript/core/theming.mdx
+++ b/appkit/javascript/core/theming.mdx
@@ -4,6 +4,4 @@ title: Theming
 
 import Theming from "/snippets/appkit/shared/theming.mdx";
 
-# Theming
-
 <Theming />

--- a/appkit/javascript/core/theming.mdx
+++ b/appkit/javascript/core/theming.mdx
@@ -1,3 +1,7 @@
+---
+title: Theming
+---
+
 import Theming from "/snippets/appkit/shared/theming.mdx";
 
 # Theming

--- a/appkit/javascript/notifications/backend-integration.mdx
+++ b/appkit/javascript/notifications/backend-integration.mdx
@@ -2,8 +2,6 @@
 title: Backend Integration
 ---
 
-# Backend Integration
-
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.
 
 We recommend testing notifications with the [Web3Inbox.com app](https://app.web3inbox.com) which supports push notifications and can be installed to your phone. You can also try one of our sample wallets:

--- a/appkit/javascript/notifications/backend-integration.mdx
+++ b/appkit/javascript/notifications/backend-integration.mdx
@@ -1,3 +1,7 @@
+---
+title: Backend Integration
+---
+
 # Backend Integration
 
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.

--- a/appkit/javascript/notifications/demo.mdx
+++ b/appkit/javascript/notifications/demo.mdx
@@ -1,3 +1,7 @@
+---
+title: Demo
+---
+
 # Demo
 
 ## Try Web3Inbox

--- a/appkit/javascript/notifications/demo.mdx
+++ b/appkit/javascript/notifications/demo.mdx
@@ -2,8 +2,6 @@
 title: Demo
 ---
 
-# Demo
-
 ## Try Web3Inbox
 
 The fastest way to try Web3Inbox is to go to [app.web3inbox.com](https://app.web3inbox.com) and try subscribing to some dapps. The [Web3Inbox.com app](https://app.web3inbox.com) is a universal inbox for web3 users to access all their notifications in one place.

--- a/appkit/javascript/notifications/frontend-integration/examples.mdx
+++ b/appkit/javascript/notifications/frontend-integration/examples.mdx
@@ -2,8 +2,6 @@
 title: Examples
 ---
 
-# Examples
-
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.
 - [React GM Dapp](https://github.com/WalletConnect/gm-dapp) - a Web3Inbox Dapp using React, Typescript, Next.js & Ethers.
 - Bare bones [template](https://github.com/WalletConnect/web3inbox-client/tree/main/apps/web) demonstrating basic functionality in an easy to base from way.

--- a/appkit/javascript/notifications/frontend-integration/examples.mdx
+++ b/appkit/javascript/notifications/frontend-integration/examples.mdx
@@ -1,3 +1,7 @@
+---
+title: Examples
+---
+
 # Examples
 
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.

--- a/appkit/javascript/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/javascript/notifications/frontend-integration/migration-guide.mdx
@@ -1,3 +1,7 @@
+---
+title: Migration Guide
+---
+
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
 # Migration Guide

--- a/appkit/javascript/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/javascript/notifications/frontend-integration/migration-guide.mdx
@@ -4,8 +4,6 @@ title: Migration Guide
 
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
-# Migration Guide
-
 ## General Migration notes
 
 - `isLimited` flag has been removed in favor of `allApps` flag. They essentially mean the opposite thing.

--- a/appkit/javascript/notifications/frontend-integration/usage.mdx
+++ b/appkit/javascript/notifications/frontend-integration/usage.mdx
@@ -5,8 +5,6 @@ title: Usage
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 
-# Usage
-
 AppKit Notifications provides you the building blocks necessary to allow users to subscribe, receive notifications, and manage notification preferences, all from your app's UI. The Web3Inbox SDK supports both React hooks and JavaScript-based integrations.
 
 Before begin using Web3Inbox, you will first need to [setup your project](../cloud-setup) to send notifications.

--- a/appkit/javascript/notifications/frontend-integration/usage.mdx
+++ b/appkit/javascript/notifications/frontend-integration/usage.mdx
@@ -1,3 +1,7 @@
+---
+title: Usage
+---
+
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 

--- a/appkit/javascript/transactions/sponsored-transactions.mdx
+++ b/appkit/javascript/transactions/sponsored-transactions.mdx
@@ -1,3 +1,6 @@
+---
+title: Sponsored Transactions
+---
 
 import SponsoredTransactions from "/snippets/appkit/shared/sponsored-transactions.mdx";
 

--- a/appkit/javascript/transactions/sponsored-transactions.mdx
+++ b/appkit/javascript/transactions/sponsored-transactions.mdx
@@ -4,6 +4,4 @@ title: Sponsored Transactions
 
 import SponsoredTransactions from "/snippets/appkit/shared/sponsored-transactions.mdx";
 
-# Sponsored Transactions
-
 <SponsoredTransactions />

--- a/appkit/javascript/transactions/swaps.mdx
+++ b/appkit/javascript/transactions/swaps.mdx
@@ -4,6 +4,4 @@ title: Swaps
 
 import Swaps from "/snippets/appkit/shared/swaps.mdx";
 
-# Swaps
-
 <Swaps/>

--- a/appkit/javascript/transactions/swaps.mdx
+++ b/appkit/javascript/transactions/swaps.mdx
@@ -1,3 +1,7 @@
+---
+title: Swaps
+---
+
 import Swaps from "/snippets/appkit/shared/swaps.mdx";
 
 # Swaps

--- a/appkit/react-native/core/hooks.mdx
+++ b/appkit/react-native/core/hooks.mdx
@@ -6,8 +6,6 @@ import WagmiHooks from "/snippets/appkit/react-native/wagmi/hooks.mdx";
 import EthersHooks from "/snippets/appkit/react-native/ethers/hooks.mdx";
 import Ethers5Hooks from "/snippets/appkit/react-native/ethers5/hooks.mdx";
 
-# Hooks
-
 ## useAppKit
 
 Control the modal with the `useAppKit` hook

--- a/appkit/react-native/core/hooks.mdx
+++ b/appkit/react-native/core/hooks.mdx
@@ -1,3 +1,7 @@
+---
+title: Hooks
+---
+
 import WagmiHooks from "/snippets/appkit/react-native/wagmi/hooks.mdx";
 import EthersHooks from "/snippets/appkit/react-native/ethers/hooks.mdx";
 import Ethers5Hooks from "/snippets/appkit/react-native/ethers5/hooks.mdx";

--- a/appkit/react-native/core/link-mode.mdx
+++ b/appkit/react-native/core/link-mode.mdx
@@ -1,3 +1,7 @@
+---
+title: Link Mode
+---
+
 # Link Mode
 
 AppKit Link Mode is a low latency mechanism for transporting One-Click Auth requests and session requests over universal links, reducing the need for a WebSocket connection with the Relay. This significantly enhances the user experience when connecting native dApps to native wallets by reducing the latency associated with networking connections, especially when the user has an unstable internet connection.

--- a/appkit/react-native/core/link-mode.mdx
+++ b/appkit/react-native/core/link-mode.mdx
@@ -2,8 +2,6 @@
 title: Link Mode
 ---
 
-# Link Mode
-
 AppKit Link Mode is a low latency mechanism for transporting One-Click Auth requests and session requests over universal links, reducing the need for a WebSocket connection with the Relay. This significantly enhances the user experience when connecting native dApps to native wallets by reducing the latency associated with networking connections, especially when the user has an unstable internet connection.
 
 <Frame>

--- a/appkit/react-native/core/options.mdx
+++ b/appkit/react-native/core/options.mdx
@@ -2,8 +2,6 @@
 title: Options
 ---
 
-# Options
-
 The following options can be passed to the `createAppKit` function:
 
 ```ts

--- a/appkit/react-native/core/options.mdx
+++ b/appkit/react-native/core/options.mdx
@@ -1,3 +1,7 @@
+---
+title: Options
+---
+
 # Options
 
 The following options can be passed to the `createAppKit` function:

--- a/appkit/react-native/core/resources.mdx
+++ b/appkit/react-native/core/resources.mdx
@@ -2,8 +2,6 @@
 title: Resources
 ---
 
-# Resources
-
 Main links for AppKit related content.
 
 - [Examples](https://github.com/reown-com/react-native-examples/tree/main/dapps)

--- a/appkit/react-native/core/resources.mdx
+++ b/appkit/react-native/core/resources.mdx
@@ -1,3 +1,7 @@
+---
+title: Resources
+---
+
 # Resources
 
 Main links for AppKit related content.

--- a/appkit/react-native/core/theming.mdx
+++ b/appkit/react-native/core/theming.mdx
@@ -2,8 +2,6 @@
 title: Theming
 ---
 
-# Theming
-
 ## ThemeMode
 
 By default `themeMode` option will be set to user system settings 'light' or 'dark'. But you can override it like this:

--- a/appkit/react-native/core/theming.mdx
+++ b/appkit/react-native/core/theming.mdx
@@ -1,3 +1,7 @@
+---
+title: Theming
+---
+
 # Theming
 
 ## ThemeMode

--- a/appkit/react-native/notifications/backend-integration.mdx
+++ b/appkit/react-native/notifications/backend-integration.mdx
@@ -2,8 +2,6 @@
 title: Backend Integration
 ---
 
-# Backend Integration
-
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.
 
 We recommend testing notifications with the [Web3Inbox.com app](https://app.web3inbox.com) which supports push notifications and can be installed to your phone. You can also try one of our sample wallets:

--- a/appkit/react-native/notifications/backend-integration.mdx
+++ b/appkit/react-native/notifications/backend-integration.mdx
@@ -1,3 +1,7 @@
+---
+title: Backend Integration
+---
+
 # Backend Integration
 
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.

--- a/appkit/react-native/notifications/demo.mdx
+++ b/appkit/react-native/notifications/demo.mdx
@@ -2,8 +2,6 @@
 title: Demo
 ---
 
-# Demo
-
 ## Try AppKit Notifications
 
 The fastest way to try AppKit Notifications is to go to [app.web3inbox.com](https://app.web3inbox.com) and try subscribing to some dapps. The [Web3Inbox.com app](https://app.web3inbox.com) is a universal inbox for web3 users to access all their notifications in one place.

--- a/appkit/react-native/notifications/demo.mdx
+++ b/appkit/react-native/notifications/demo.mdx
@@ -1,3 +1,7 @@
+---
+title: Demo
+---
+
 # Demo
 
 ## Try AppKit Notifications

--- a/appkit/react-native/notifications/frontend-integration/examples.mdx
+++ b/appkit/react-native/notifications/frontend-integration/examples.mdx
@@ -2,8 +2,6 @@
 title: Examples
 ---
 
-# Examples
-
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.
 - [React GM Dapp](https://github.com/WalletConnect/gm-dapp) - a Web3Inbox Dapp using React, Typescript, Next.js & Ethers.
 - Bare bones [template](https://github.com/WalletConnect/web3inbox-client/tree/main/apps/web) demonstrating basic functionality in an easy to base from way.

--- a/appkit/react-native/notifications/frontend-integration/examples.mdx
+++ b/appkit/react-native/notifications/frontend-integration/examples.mdx
@@ -1,3 +1,7 @@
+---
+title: Examples
+---
+
 # Examples
 
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.

--- a/appkit/react-native/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/react-native/notifications/frontend-integration/migration-guide.mdx
@@ -1,3 +1,7 @@
+---
+title: Migration Guide
+---
+
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
 # Migration Guide

--- a/appkit/react-native/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/react-native/notifications/frontend-integration/migration-guide.mdx
@@ -4,8 +4,6 @@ title: Migration Guide
 
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
-# Migration Guide
-
 ## General Migration notes
 
 - `isLimited` flag has been removed in favor of `allApps` flag. They essentially mean the opposite thing.

--- a/appkit/react-native/notifications/frontend-integration/usage.mdx
+++ b/appkit/react-native/notifications/frontend-integration/usage.mdx
@@ -5,8 +5,6 @@ title: Usage
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 
-# Usage
-
 AppKit Notifications provides you the building blocks necessary to allow users to subscribe, receive notifications, and manage notification preferences, all from your app's UI. The Web3Inbox SDK supports both React hooks and JavaScript-based integrations.
 
 Before begin using Web3Inbox, you will first need to [setup your project](../cloud-setup) to send notifications.

--- a/appkit/react-native/notifications/frontend-integration/usage.mdx
+++ b/appkit/react-native/notifications/frontend-integration/usage.mdx
@@ -1,3 +1,7 @@
+---
+title: Usage
+---
+
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 

--- a/appkit/vue/core/composables.mdx
+++ b/appkit/vue/core/composables.mdx
@@ -1,3 +1,7 @@
+---
+title: Composables
+---
+
 import WagmiComposables from "/snippets/appkit/vue/wagmi/composables.mdx";
 import EthersComposables from "/snippets/appkit/vue/ethers/composables.mdx";
 import Ethers5Composables from "/snippets/appkit/vue/ethers5/composables.mdx";

--- a/appkit/vue/core/composables.mdx
+++ b/appkit/vue/core/composables.mdx
@@ -8,8 +8,6 @@ import Ethers5Composables from "/snippets/appkit/vue/ethers5/composables.mdx";
 import SolanaComposables from "/snippets/appkit/vue/solana/composables.mdx";
 import OpenModal from "/snippets/appkit/vue/core/open.mdx";
 
-# Composables
-
 Composables are functions that will help you control the modal, subscribe to wallet events and interact with them and smart contracts.
 
 ## useAppKit

--- a/appkit/vue/core/custom-connectors.mdx
+++ b/appkit/vue/core/custom-connectors.mdx
@@ -1,3 +1,7 @@
+---
+title: Custom connectors
+---
+
 # Custom connectors
 
 Add custom connectors for Ethers or Wagmi

--- a/appkit/vue/core/custom-connectors.mdx
+++ b/appkit/vue/core/custom-connectors.mdx
@@ -2,8 +2,6 @@
 title: Custom connectors
 ---
 
-# Custom connectors
-
 Add custom connectors for Ethers or Wagmi
 
 <Tabs>

--- a/appkit/vue/core/theming.mdx
+++ b/appkit/vue/core/theming.mdx
@@ -4,6 +4,4 @@ title: Theming
 
 import Theming from "/snippets/appkit/shared/theming.mdx";
 
-# Theming
-
 <Theming />

--- a/appkit/vue/core/theming.mdx
+++ b/appkit/vue/core/theming.mdx
@@ -1,3 +1,7 @@
+---
+title: Theming
+---
+
 import Theming from "/snippets/appkit/shared/theming.mdx";
 
 # Theming

--- a/appkit/vue/notifications/backend-integration.mdx
+++ b/appkit/vue/notifications/backend-integration.mdx
@@ -2,8 +2,6 @@
 title: Backend Integration
 ---
 
-# Backend Integration
-
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.
 
 We recommend testing notifications with the [Web3Inbox.com app](https://app.web3inbox.com) which supports push notifications and can be installed to your phone. You can also try one of our sample wallets:

--- a/appkit/vue/notifications/backend-integration.mdx
+++ b/appkit/vue/notifications/backend-integration.mdx
@@ -1,3 +1,7 @@
+---
+title: Backend Integration
+---
+
 # Backend Integration
 
 Once an account is subscribed to your app's notifications you can test sending notifications to the account. You can subscribe in your app directly with our [Frontend Integration](frontend-integration/usage), or with one of the below testing options.

--- a/appkit/vue/notifications/cloud-sending.mdx
+++ b/appkit/vue/notifications/cloud-sending.mdx
@@ -1,3 +1,7 @@
+---
+title: Sending with Cloud
+---
+
 # Sending with Cloud
 
 You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.

--- a/appkit/vue/notifications/cloud-sending.mdx
+++ b/appkit/vue/notifications/cloud-sending.mdx
@@ -2,8 +2,6 @@
 title: Sending with Cloud
 ---
 
-# Sending with Cloud
-
 You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.

--- a/appkit/vue/notifications/cloud-setup.mdx
+++ b/appkit/vue/notifications/cloud-setup.mdx
@@ -1,3 +1,7 @@
+---
+title: Cloud Setup
+---
+
 import CloudBanner from "/snippets/cloud-banner.mdx";
 
 # Cloud Setup

--- a/appkit/vue/notifications/cloud-setup.mdx
+++ b/appkit/vue/notifications/cloud-setup.mdx
@@ -4,8 +4,6 @@ title: Cloud Setup
 
 import CloudBanner from "/snippets/cloud-banner.mdx";
 
-# Cloud Setup
-
 This page explains the configuration required in order to obtain a Notify API Secret and configure your project to send notifications.
 
 For a quick start to experiment with, you can try the [web3inbox template](https://github.com/WalletConnect/web3inbox-client/tree/main/apps/web) and following the steps in the README.

--- a/appkit/vue/notifications/demo.mdx
+++ b/appkit/vue/notifications/demo.mdx
@@ -2,8 +2,6 @@
 title: Demo
 ---
 
-# Demo
-
 ## Try AppKit Notifications
 
 The fastest way to try AppKit Notifications is to go to [app.web3inbox.com](https://app.web3inbox.com) and try subscribing to some dapps. The [Web3Inbox.com app](https://app.web3inbox.com) is a universal inbox for web3 users to access all their notifications in one place.

--- a/appkit/vue/notifications/demo.mdx
+++ b/appkit/vue/notifications/demo.mdx
@@ -1,3 +1,7 @@
+---
+title: Demo
+---
+
 # Demo
 
 ## Try AppKit Notifications

--- a/appkit/vue/notifications/frontend-integration/api.mdx
+++ b/appkit/vue/notifications/frontend-integration/api.mdx
@@ -1,3 +1,7 @@
+---
+title: API
+---
+
 import CloudBanner from "/snippets/cloud-banner.mdx";
 
 import Initialization from "/snippets/appkit/shared/notifications/frontend-integration/api/initialization/javascript.mdx";

--- a/appkit/vue/notifications/frontend-integration/api.mdx
+++ b/appkit/vue/notifications/frontend-integration/api.mdx
@@ -13,8 +13,6 @@ import Types from "/snippets/appkit/shared/notifications/frontend-integration/ap
 import RegisteringPush from "/snippets/appkit/shared/notifications/frontend-integration/api/registering-push/javascript.mdx";
 import Events from "/snippets/appkit/shared/notifications/frontend-integration/api/events/javascript.mdx";
 
-# API
-
 ## Initialization
 
 <Initialization />

--- a/appkit/vue/notifications/frontend-integration/examples.mdx
+++ b/appkit/vue/notifications/frontend-integration/examples.mdx
@@ -2,8 +2,6 @@
 title: Examples
 ---
 
-# Examples
-
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.
 - [React GM Dapp](https://github.com/WalletConnect/gm-dapp) - a Web3Inbox Dapp using React, Typescript, Next.js & Ethers.
 - Bare bones [template](https://github.com/WalletConnect/web3inbox-client/tree/main/apps/web) demonstrating basic functionality in an easy to base from way.

--- a/appkit/vue/notifications/frontend-integration/examples.mdx
+++ b/appkit/vue/notifications/frontend-integration/examples.mdx
@@ -1,3 +1,7 @@
+---
+title: Examples
+---
+
 # Examples
 
 - Our production [GM App](https://gm.walletconnect.com) which sends daily "gm!" notifications to all subscribers.

--- a/appkit/vue/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/vue/notifications/frontend-integration/migration-guide.mdx
@@ -1,3 +1,7 @@
+---
+title: Migration Guide
+---
+
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
 # Migration Guide

--- a/appkit/vue/notifications/frontend-integration/migration-guide.mdx
+++ b/appkit/vue/notifications/frontend-integration/migration-guide.mdx
@@ -4,8 +4,6 @@ title: Migration Guide
 
 import Migration from "/snippets/appkit/shared/notifications/frontend-integration/migration/javascript.mdx";
 
-# Migration Guide
-
 ## General Migration notes
 
 - `isLimited` flag has been removed in favor of `allApps` flag. They essentially mean the opposite thing.

--- a/appkit/vue/notifications/frontend-integration/usage.mdx
+++ b/appkit/vue/notifications/frontend-integration/usage.mdx
@@ -5,8 +5,6 @@ title: Usage
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 
-# Usage
-
 AppKit Notifications provides you the building blocks necessary to allow users to subscribe, receive notifications, and manage notification preferences, all from your app's UI. The Web3Inbox SDK supports both React hooks and JavaScript-based integrations.
 
 Before begin using Web3Inbox, you will first need to [setup your project](../cloud-setup) to send notifications.

--- a/appkit/vue/notifications/frontend-integration/usage.mdx
+++ b/appkit/vue/notifications/frontend-integration/usage.mdx
@@ -1,3 +1,7 @@
+---
+title: Usage
+---
+
 import Installation from "/snippets/appkit/shared/notifications/frontend-integration/usage/installation/javascript.mdx";
 import Example from "/snippets/appkit/shared/notifications/frontend-integration/usage/example/javascript.mdx";
 

--- a/appkit/vue/transactions/sponsored-transactions.mdx
+++ b/appkit/vue/transactions/sponsored-transactions.mdx
@@ -1,3 +1,7 @@
+---
+title: Sponsored Transactions
+---
+
 import SponsoredTransactions from "/snippets/appkit/shared/sponsored-transactions.mdx";
 
 # Sponsored Transactions

--- a/appkit/vue/transactions/sponsored-transactions.mdx
+++ b/appkit/vue/transactions/sponsored-transactions.mdx
@@ -4,6 +4,4 @@ title: Sponsored Transactions
 
 import SponsoredTransactions from "/snippets/appkit/shared/sponsored-transactions.mdx";
 
-# Sponsored Transactions
-
 <SponsoredTransactions />

--- a/appkit/vue/transactions/swaps.mdx
+++ b/appkit/vue/transactions/swaps.mdx
@@ -4,6 +4,4 @@ title: Swaps
 
 import Swaps from "/snippets/appkit/shared/swaps.mdx";
 
-# Swaps
-
 <Swaps />

--- a/appkit/vue/transactions/swaps.mdx
+++ b/appkit/vue/transactions/swaps.mdx
@@ -1,3 +1,7 @@
+---
+title: Swaps
+---
+
 import Swaps from "/snippets/appkit/shared/swaps.mdx";
 
 # Swaps


### PR DESCRIPTION
## Description

**Context:**
Several documentation pages linked within the project were initially missing titles (represented by `[null](...)` in https://docs.reown.com/llms.txt). Additionally, after adding titles via frontmatter, the top-level H1 headings (`# Heading`) in these files became redundant/duplicative, as the title is already rendered by mintlify based on the frontmatter.

**Solution:**
This PR addresses both issues in two steps:

1.  **Add Missing Titles:**
    - Identified all markdown links with `[null]` as the link text.
    - For each corresponding `.mdx` file lacking a title in its frontmatter, extracted the main H1 heading.
    - Added `title: <Extracted Heading>` to the frontmatter of these files.
    *(Commit: `docs: add missing titles to mdx files`)*

2.  **Remove Redundant H1 Headings:**
    - For all files modified in the previous step, removed the now-redundant top-level H1 markdown heading (`# Heading`). This avoids potential duplicate titles in the rendered documentation.
    *(Commit: `refactor(docs): remove redundant H1 headings after adding frontmatter titles`)*

**Benefits:**
- Fixes the llms.txt issue
- Improves documentation structure and consistency.
- Ensures correct title rendering by the documentation framework.
- Enhances navigation and potentially SEO.

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.