### PR TITLE
[Typo] Fix tab title

### DIFF
--- a/snippets/appkit/shared/bitcoin-provider.mdx
+++ b/snippets/appkit/shared/bitcoin-provider.mdx
@@ -28,7 +28,7 @@ export interface BitcoinConnector extends ChainAdapterConnector, Provider {
   }
 ```
 </Tab>
-<Tab title="SignMessageParams">
+<Tab title="SendTransferParams">
 ```ts
   export type SendTransferParams = {
     /**


### PR DESCRIPTION
Update bitcoin-provider.mdx

## Description

Incorrect tab title: `SignMessageParams` -> `SendTransferParams`

