### PR TITLE
Docs Update: Adding contextual copy and open options to the docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -50,6 +50,9 @@
       "destination": "/advanced/multichain/rpc-reference/:path*"
     }
   ],
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "claude"]
+  },
   "navigation": {
     "tabs": [
       {


### PR DESCRIPTION
## Description

Mintlify launched a new feature to enable a contextual menu for every page of the docs. This allows readers to copy and view a given doc page as markdown. It also allows them to open the doc page in ChatGPT and Claude to ask questions. 

More info about the feature can be found [here](https://mintlify.com/docs/core-concepts/ai-ingestion#contextual-menu). 

This PR adds the `contextual` param to the `docs.json` file for this purpose. 

![image](https://github.com/user-attachments/assets/f07296d0-c22d-4c04-9725-06ec4151e697)


## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.