### PR TITLE
Docs Update: Final improvements to AppKit Core upgrade doc

### DIFF
--- a/appkit/upgrade/wcm.mdx
+++ b/appkit/upgrade/wcm.mdx
@@ -26,6 +26,10 @@ Please, follow the different sections based on which package you were using befo
 
 You first need to install the AppKit package in order to get started. You can do this by running the command below.
 
+<Note>
+  Make sure to use a version equal or greater than v1.7.0
+</Note>
+
 <CodeGroup>
 
 ```bash npm
@@ -45,83 +49,11 @@ pnpm add @reown/appkit
 ```
 </CodeGroup>
 
-<Note>
-  Make sure to use a version equal or greater than v1.7.0
-</Note>
+### Setting up AppKit Core from scratch?
 
-## AppKit Core
+If you are setting up AppKit Core from scratch, you can refer to the "Multichain" section under AppKit "Core" for installation which shows a basic installation of AppKit Core. [Click here](/appkit/react/core/multichain?platform=basic) to learn more.
 
-This is the easiest way for developers to go multi-chain. AppKit Core utilizes the `UniversalProvider` underneath and is a ready-to-use solution with hooks and methods.
-
-<Tabs
-	
-	
->
-<Tab title="React">
-```javascript
-import { createAppKit } from '@reown/appkit/react'
-import { mainnet } from '@reown/appkit/networks'
-
-const modal = createAppKit({
-  adapters: [], //pass an empty array to only use WalletConnect QR
-  projectId: 'YOUR_PROJECT_ID',
-  metadata: {
-    name: 'My Website',
-    description: 'My Website Description',
-    url: 'https://mywebsite.com', // origin must match your domain & subdomain
-    icons: ['https://avatars.githubusercontent.com/u/37784886']
-  },
-  networks: [mainnet]
-})
-
-```
-</Tab>
-
-<Tab title="JavaScript">
-```javascript
-import { createAppKit } from '@reown/appkit'
-import { mainnet } from '@reown/appkit/networks'
-
-const modal = createAppKit({
-  adapters: [], //pass an empty array to only use WalletConnect QR
-  projectId: 'YOUR_PROJECT_ID',
-  metadata: {
-    name: 'My Website',
-    description: 'My Website Description',
-    url: 'https://mywebsite.com', // origin must match your domain & subdomain
-    icons: ['https://avatars.githubusercontent.com/u/37784886']
-  },
-  networks: [mainnet]
-})
-```
-
-</Tab>
-
-<Tab title="Vue">
-```javascript
-import { createAppKit } from '@reown/appkit/vue'
-import { mainnet } from '@reown/appkit/networks'
-
-const modal = createAppKit({
-  adapters: [], //pass an empty array to only use WalletConnect QR
-  projectId: 'YOUR_PROJECT_ID',
-  metadata: {
-    name: 'My Website',
-    description: 'My Website Description',
-    url: 'https://mywebsite.com', // origin must match your domain & subdomain
-    icons: ['https://avatars.githubusercontent.com/u/37784886']
-  },
-  networks: [mainnet]
-})
-
-```
-</Tab>
-
-</Tabs>
-
-You can also refer to the "Multichain" section under AppKit "Core" for installation which shows a basic installation of AppKit Core. [Click here](/appkit/react/core/multichain?platform=basic) to learn more.
-
-### Examples
+#### Examples
 
 Below are the examples for the corresponding library/programming language.
 
@@ -132,37 +64,7 @@ Below are the examples for the corresponding library/programming language.
 
 ## Ethereum Provider
 
-The Ethereum Provider implementation remains the same as before. Below is an example of how you can configure it:
-
-```javascript
-import { EthereumProvider } from '@walletconnect/ethereum-provider'
-
-const provider = await EthereumProvider.init({
-  projectId: 'YOUR_PROJECT_ID',
-  metadata: {
-    name: 'My Website',
-    description: 'My Website Description',
-    url: 'https://mywebsite.com', // origin must match your domain & subdomain
-    icons: ['https://avatars.githubusercontent.com/u/37784886']
-  },
-  showQrModal: true,
-  optionalChains: [1, 137, 2020],
-
-  /*Optional - Add custom RPCs for each supported chain*/
-  rpcMap: {
-    1: 'mainnet.rpc...',
-    137: 'polygon.rpc...'
-  }
-})
-
-
-// Connect EthereumProvider, this will open modal
-await provider.connect()
-```
-
-### Changes Required
-
-Projects and developers don't need to change anything in their configuration - upgrading the Ethereum Provider to latest version is sufficient. Projects will automatically receive the new QR modal UI.
+The Ethereum Provider implementation remains the same as before. **Projects and developers don't need to change anything in their configuration; upgrading the Ethereum Provider to latest version is sufficient.** Projects will automatically receive the new QR modal UI.
 
 <Note>
 Not all `themeVariables`will be compatible with the new UI, as `AppKit` uses a different design system than `walletConnectModal`

--- a/appkit/upgrade/wcm.mdx
+++ b/appkit/upgrade/wcm.mdx
@@ -82,7 +82,7 @@ Below are the examples for the corresponding library/programming language.
 
 ## Universal Provider
 
-First, please uninstall the `@walletconnect/modal` package.
+First, please uninstall the `@walletconnect/modal` package. You should also remove `@walletconnect/modal` from your `package.json` file.
 
 <CodeGroup>
 
@@ -275,7 +275,7 @@ Below are the examples for the corresponding library/programming language.
 
 ## Sign Client
 
-First, please uninstall the `@walletconnect/modal` package.
+First, please uninstall the `@walletconnect/modal` package. You should also remove `@walletconnect/modal` from your `package.json` file.
 
 <CodeGroup>
 

--- a/appkit/upgrade/wcm.mdx
+++ b/appkit/upgrade/wcm.mdx
@@ -15,12 +15,17 @@ title: WalletConnect Modal to Reown AppKit Core
   ></video>
 </Frame>
 
-Please, follow the different sections based on which package you were using before. **AppKit Core** is the most basic version of Reown AppKit which  replaces WalletConnect Modal. Please refer to the AppKit Core section if you are starting from scratch.
+Please, follow the different sections based on which package you were using before.
 
-1. [**AppKit Core**](#appkit-core)
-2. [**Ethereum Provider**](#ethereum-provider)
-3. [**Universal Provider**](#universal-provider)
-4. [**Sign Client**](#sign-client)
+1. [**Ethereum Provider**](#ethereum-provider)
+2. [**Universal Provider**](#universal-provider)
+3. [**Sign Client**](#sign-client)
+
+<Note>
+If your project has `@walletconnect/modal` in the `package.json` or your project files, you need to remove it and uninstall it. After that, you can refer to the [Universal Provider path](##universal-provider) to setup AppKit Core in your project.
+</Note>
+
+ **AppKit Core** is the most basic version of Reown AppKit which replaces WalletConnect Modal. Please refer to [this section](#setting-up-appkit-core-from-scratch%3F) if you are starting from scratch.
 
 ## Installation
 

--- a/appkit/upgrade/wcm.mdx
+++ b/appkit/upgrade/wcm.mdx
@@ -17,9 +17,10 @@ title: WalletConnect Modal to Reown AppKit Core
 
 Please, follow the different sections based on which package you were using before.
 
-1. [**Ethereum Provider**](#ethereum-provider)
-2. [**Universal Provider**](#universal-provider)
-3. [**Sign Client**](#sign-client)
+1. [**`@walletconnect/ethereum-provider`**](#ethereum-provider)
+2. [**`@walletconnect/universal-provider`**](#universal-provider)
+3. [**`@walletconnect/sign-client`**](#sign-client)
+4. [**`@walletconnect/modal`**](#universal-provider)
 
 <Note>
 If your project has `@walletconnect/modal` in the `package.json` or your project files, you need to remove it and uninstall it. After that, you can refer to the [Universal Provider path](#universal-provider) to setup AppKit Core in your project.

--- a/appkit/upgrade/wcm.mdx
+++ b/appkit/upgrade/wcm.mdx
@@ -22,10 +22,10 @@ Please, follow the different sections based on which package you were using befo
 3. [**Sign Client**](#sign-client)
 
 <Note>
-If your project has `@walletconnect/modal` in the `package.json` or your project files, you need to remove it and uninstall it. After that, you can refer to the [Universal Provider path](##universal-provider) to setup AppKit Core in your project.
+If your project has `@walletconnect/modal` in the `package.json` or your project files, you need to remove it and uninstall it. After that, you can refer to the [Universal Provider path](#universal-provider) to setup AppKit Core in your project.
 </Note>
 
- **AppKit Core** is the most basic version of Reown AppKit which replaces WalletConnect Modal. Please refer to [this section](#setting-up-appkit-core-from-scratch%3F) if you are starting from scratch.
+ **AppKit Core** is the most basic version of Reown AppKit which replaces WalletConnect Modal. Please refer to [this section](#setting-up-appkit-core-from-scratch) if you are starting from scratch.
 
 ## Installation
 
@@ -53,19 +53,6 @@ bun add @reown/appkit
 pnpm add @reown/appkit
 ```
 </CodeGroup>
-
-### Setting up AppKit Core from scratch?
-
-If you are setting up AppKit Core from scratch, you can refer to the "Multichain" section under AppKit "Core" for installation which shows a basic installation of AppKit Core. [Click here](/appkit/react/core/multichain?platform=basic) to learn more.
-
-#### Examples
-
-Below are the examples for the corresponding library/programming language.
-
-1. [HTML](https://github.com/reown-com/appkit/tree/main/examples/html-ak-basic)
-2. [React](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic)
-3. [NextJS](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-app-router)
-4. [Vue](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic)
 
 ## Ethereum Provider
 
@@ -464,3 +451,16 @@ Below are the examples for the corresponding library/programming language.
 2. [React](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic-sign-client)
 3. [NextJS](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-sign-client-app-router)
 4. [Vue](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic-sign-client)
+
+## Setting up AppKit Core from scratch
+
+If you are setting up AppKit Core from scratch, you can refer to the "Multichain" section under AppKit "Core" for installation which shows a basic installation of AppKit Core. [Click here](/appkit/react/core/multichain?platform=basic) to learn more.
+
+### Examples
+
+Below are the examples for the corresponding library/programming language.
+
+1. [HTML](https://github.com/reown-com/appkit/tree/main/examples/html-ak-basic)
+2. [React](https://github.com/reown-com/appkit/tree/main/examples/react-ak-basic)
+3. [NextJS](https://github.com/reown-com/appkit/tree/main/examples/next-ak-basic-app-router)
+4. [Vue](https://github.com/reown-com/appkit/tree/main/examples/vue-ak-basic)

--- a/docs.json
+++ b/docs.json
@@ -274,7 +274,8 @@
                             ]
                           }
                         ]
-                      }
+                      },
+                      "appkit/upgrade/wcm"
                     ]
                   },
                   {


### PR DESCRIPTION
## Description

This PR does the following:
1. Adds AppKit Core upgrade guide to the sidebar.
2. Removes AppKit Core set up from the upgrade doc. 
3. Adds a note that for projects that have `@walletconnect/modal` to remove it and refer to the Universal Provider path to set up AppKit Core/WalletConnect.
4. Adds a brief paragraph about the docs page that devs should refer to if they are looking to set up AppKit Core from scratch.
5. Removes code snippet for Ethereum Provider and highlights that developers using this do not need to take any action.

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.