### PR TITLE
Docs Update: Add info about assets and networks supported to AppKit Pay

### DIFF
--- a/appkit/payments/pay-with-exchange.mdx
+++ b/appkit/payments/pay-with-exchange.mdx
@@ -35,6 +35,18 @@ Want to see AppKit Pay with Exchange in action? Try out the live demo to experie
     <Card icon="flask" title="Try Demo" href="https://appkit-lab.reown.com/library/pay-default/?utm_source=appkit-pay-with-exchange&utm_medium=docs&utm_campaign=backlinks" external />
 </CardGroup>
 
+## Networks and Assets Supported
+
+Currently, AppKit Pay with Exchange and Self-Custodial Wallets supports the following assets on the following networks:
+
+| Asset   | Network          |
+|-----------|-----------------|
+| USDC, USDT, ETH | Optimism, Arbitrum, Base, Polygon |
+
+**Any EVM network and its assets can be supported, subject to exchange compatibility.** Support for Solana is coming soon.
+
+For access to additional networks or assets, please contact sales@reown.com.
+
 ## Interested in getting early access?
 
 This feature is currently in early access. If you are **interested in getting early access** or learning more, **please reach out to us at sales@reown.com.**


### PR DESCRIPTION
## Description

This PR adds info about tokens and networks supported by AppKit Pay. 

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.