### PR TITLE
Docs Update: Renaming "Smart Sessions" in the docs and adding more context

### DIFF
--- a/appkit/features/smart-sessions.mdx
+++ b/appkit/features/smart-sessions.mdx
@@ -54,6 +54,16 @@ In order to try out the demo, you need to use the email login flow. If your emai
 
 - **In-Game Transactions**: Allow games to perform actions like purchasing items or allocating resources without interrupting gameplay. 
 
+## Supported Networks
+
+Currently, Smart Sessions are supported on Ethereum Sepolia and Base Sepolia. 
+
+It will soon be available on Base Mainnet and all EVM chains supported by AppKit's [Smart Accounts](/appkit/features/smart-accounts). 
+
+<Note>
+Looking to add support for other networks? Contact sales@reown.com.
+</Note>
+
 ## Get Started
 
 <CardGroup cols={2}>

--- a/appkit/features/smart-sessions.mdx
+++ b/appkit/features/smart-sessions.mdx
@@ -1,6 +1,6 @@
 ---
 title: Smart Sessions
-
+sidebarTitle: Automated Onchain Actions (Smart Sessions)
 ---
 
 Smart Sessions is a feature in Reown AppKit that allows users to grant decentralized applications (dApps) permission to perform specific blockchain actions on their behalf for a defined period of time. This eliminates the need for users to manually approve each transaction, enhancing the user experience by enabling seamless and automated interactions.

--- a/appkit/features/smart-sessions.mdx
+++ b/appkit/features/smart-sessions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Smart Sessions
+title: Automated Onchain Actions (Smart Sessions)
 sidebarTitle: Automated Onchain Actions (Smart Sessions)
 ---
 


### PR DESCRIPTION
## Description

This PR renames "Smart Sessions" to "Automated Onchain Actions" and also adds info about the networks supported.

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.