### PR TITLE
fix: add `com.reown.unity.dependencies` dependency to the Unity install docs

### DIFF
--- a/appkit/unity/core/installation.mdx
+++ b/appkit/unity/core/installation.mdx
@@ -52,6 +52,7 @@ openupm add com.reown.appkit.unity
    - `com.reown.sign.nethereum`
    - `com.reown.sign.nethereum.unity`
    - `com.reown.appkit.unity`
+   - `com.reown.unity.dependencies`
 7. Press `Add` button
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Description

Add `com.reown.unity.dependencies` dependency to the Unity install docs

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.