### PR TITLE
docs: call useAppKitProvider correctly

### DIFF
--- a/appkit/recipes/EVM-smart-contract-interaction.mdx
+++ b/appkit/recipes/EVM-smart-contract-interaction.mdx
@@ -144,7 +144,7 @@ import type { Provider } from "@reown/appkit/react";
 2. Call the AppKit Provider hook:
 
 ```jsx
-const { walletProvider } = useAppKitProvider < Provider > "eip155";
+const { walletProvider } = useAppKitProvider<Provider>("eip155");
 ```
 
 3. Generate the actions calling the functions:

--- a/appkit/recipes/bitcoin-send-transaction.mdx
+++ b/appkit/recipes/bitcoin-send-transaction.mdx
@@ -47,7 +47,7 @@ import type { BitcoinConnector } from "@reown/appkit-adapter-bitcoin";
 
 ```js
 // Get the wallet provider with the AppKit hook
-const { walletProvider } = useAppKitProvider < BitcoinConnector > "bip122";
+const { walletProvider } = useAppKitProvider<BitcoinConnector>("bip122");
 
 // AppKit hook to get the address and check if the user is connected
 const { allAccounts, address, isConnected } = useAppKitAccount();

--- a/appkit/recipes/ethers-send-transaction.mdx
+++ b/appkit/recipes/ethers-send-transaction.mdx
@@ -65,7 +65,7 @@ const { address, isConnected } = useAppKitAccount();
 // AppKit hook to get the chain id
 const { chainId } = useAppKitNetworkCore();
 // AppKit hook to get the wallet provider
-const { walletProvider } = useAppKitProvider < Provider > "eip155";
+const { walletProvider } = useAppKitProvider<Provider>("eip155");
 ```
 
 ### Get Balance

--- a/appkit/recipes/solana-send-transaction.mdx
+++ b/appkit/recipes/solana-send-transaction.mdx
@@ -117,7 +117,7 @@ import type { Provider } from "@reown/appkit-adapter-solana/react";
 
 ```js
 // Get the wallet provider with the AppKit hook
-const { walletProvider } = useAppKitProvider < Provider > "solana";
+const { walletProvider } = useAppKitProvider<Provider>("solana");
 
 // AppKit hook to get the address and check if the user is connected
 const { address, isConnected } = useAppKitAccount();
@@ -169,7 +169,7 @@ import type { Provider } from "@reown/appkit-adapter-solana/react";
 ```js
 const { isConnected, address } = useAppKitAccount();
 const { connection } = useAppKitConnection();
-const { walletProvider } = useAppKitProvider < Provider > "solana";
+const { walletProvider } = useAppKitProvider<Provider>("solana");
 ```
 
 3. Create the function to raise the modal to send the transaction


### PR DESCRIPTION
## Description

The docs have several occurences of usage of `useAppKitProvider` without brackets, which just doesn't work (not a function call). This PR fixes them (or at least some of them, since github.dev has limited search capabilities).