### PR TITLE
Docs Update: Fixing network specific links and other improvements

### DIFF
--- a/appkit/android/core/one-click-auth.mdx
+++ b/appkit/android/core/one-click-auth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sign In With Ethereum
-sidebarTitle: One-Click Auth / SIWE
+sidebarTitle: One-Click Auth (SIWE)
 ---
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a form of authentication that enables users to control their digital identity with their Ethereum account. SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).

--- a/appkit/flutter/core/siwe.mdx
+++ b/appkit/flutter/core/siwe.mdx
@@ -1,5 +1,5 @@
 ---
-title: One-Click Auth / SIWE
+title: One-Click Auth (SIWE)
 ---
 
 # Sign In With Ethereum

--- a/appkit/flutter/core/siwe.mdx
+++ b/appkit/flutter/core/siwe.mdx
@@ -1,8 +1,7 @@
 ---
-title: One-Click Auth (SIWE)
+title: Sign In With Ethereum
+sidebarTitle: One-Click Auth (SIWE)
 ---
-
-# Sign In With Ethereum
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a new form of authentication that enables users to control their digital identity with their Ethereum account.
 SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).

--- a/appkit/ios/core/one-click-auth.mdx
+++ b/appkit/ios/core/one-click-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: One-Click Auth / SIWE
+title: One-Click Auth (SIWE)
 ---
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a form of authentication that enables users to control their digital identity with their Ethereum account. SIWE is a standard also known as EIP-4361.

--- a/appkit/javascript/core/siwe.mdx
+++ b/appkit/javascript/core/siwe.mdx
@@ -6,8 +6,6 @@ sidebarTitle: One-Click Auth (SIWE)
 import SiweCode from "/snippets/appkit/shared/siwe/code.mdx";
 import SiweParams from "/snippets/appkit/shared/siwe/parameters.mdx";
 
-# Sign In With Ethereum
-
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a new form of authentication that enables users to control their digital identity with their Ethereum account.
 SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).
 

--- a/appkit/javascript/core/siwe.mdx
+++ b/appkit/javascript/core/siwe.mdx
@@ -1,5 +1,6 @@
 ---
-title: One-Click Auth / SIWE
+title: Sign In With Ethereum
+sidebarTitle: One-Click Auth (SIWE)
 ---
 
 import SiweCode from "/snippets/appkit/shared/siwe/code.mdx";

--- a/appkit/networks/bitcoin.mdx
+++ b/appkit/networks/bitcoin.mdx
@@ -24,11 +24,11 @@ If your wallet supports a mentioned standard but you cannot connect, please reac
 ## Get Started
 
 <CardGroup cols={2}>
-  <Card title="React" icon="react" href="/appkit/react/core/installation?platform=bitcoin">
+  <Card title="React" icon="react" href="/appkit/react/core/installation#bitcoin">
     Get started with AppKit in React.
   </Card>
 
-  <Card title="Next.js" icon="square-n" href="/appkit/next/core/installation?platform=bitcoin">
+  <Card title="Next.js" icon="square-n" href="/appkit/next/core/installation#bitcoin">
     Get started with AppKit in Next.js.
   </Card>
 

--- a/appkit/networks/bitcoin.mdx
+++ b/appkit/networks/bitcoin.mdx
@@ -32,11 +32,11 @@ If your wallet supports a mentioned standard but you cannot connect, please reac
     Get started with AppKit in Next.js.
   </Card>
 
-  <Card title="Vue" icon="vuejs" href="/appkit/vue/core/installation?platform=bitcoin">
+  <Card title="Vue" icon="vuejs" href="/appkit/vue/core/installation#bitcoin">
     Get started with AppKit in Vue.
   </Card>
 
-  <Card title="JavaScript" icon="js" href="/appkit/javascript/core/installation?platform=bitcoin">
+  <Card title="JavaScript" icon="js" href="/appkit/javascript/core/installation#bitcoin">
     Get started with AppKit in JavaScript.
   </Card>
 </CardGroup>

--- a/appkit/networks/solana.mdx
+++ b/appkit/networks/solana.mdx
@@ -28,11 +28,11 @@ The AppKit SDK supports Solana, allowing users to connect their Solana wallets t
     Get started with AppKit in Next.js.
   </Card>
 
-  <Card title="Vue" icon="vuejs" href="/appkit/vue/core/installation?platform=solana">
+  <Card title="Vue" icon="vuejs" href="/appkit/vue/core/installation#solana">
     Get started with AppKit in Vue.
   </Card>
 
-  <Card title="JavaScript" icon="js" href="/appkit/javascript/core/installation?platform=solana">
+  <Card title="JavaScript" icon="js" href="/appkit/javascript/core/installation#solana">
     Get started with AppKit in JavaScript.
   </Card>
 </CardGroup>

--- a/appkit/networks/solana.mdx
+++ b/appkit/networks/solana.mdx
@@ -20,11 +20,11 @@ The AppKit SDK supports Solana, allowing users to connect their Solana wallets t
 ## Get Started
 
 <CardGroup cols={2}>
-  <Card title="React" icon="react" href="/appkit/react/core/installation?platform=solana">
+  <Card title="React" icon="react" href="/appkit/react/core/installation#solana">
     Get started with AppKit in React.
   </Card>
 
-  <Card title="Next.js" icon="square-n" href="/appkit/next/core/installation?platform=solana">
+  <Card title="Next.js" icon="square-n" href="/appkit/next/core/installation#solana">
     Get started with AppKit in Next.js.
   </Card>
 

--- a/appkit/next/core/siwe.mdx
+++ b/appkit/next/core/siwe.mdx
@@ -1,8 +1,7 @@
 ---
 title: Sign In With Ethereum
-sidebarTitle: One-Click Auth / SIWE
+sidebarTitle: One-Click Auth (SIWE)
 ---
-
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a new form of authentication that enables users to control their digital identity with their Ethereum account.
 SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).

--- a/appkit/payments/one-click-checkout.mdx
+++ b/appkit/payments/one-click-checkout.mdx
@@ -25,7 +25,9 @@ Perfect for merchants and payment providers who want to **maximize conversions**
 ***One click. One user journey. Zero friction.***
 
 <Note>
-    This feature is currently in early access and is about to launch soon. If you are interested in getting early access or learning more, please reach out to us at sales@reown.com.
+    This feature is currently in early access and is about to launch soon.     Wallets will need to support `wallet_checkout` method for this feature to work as expected. 
+    
+    We recommend checking with us to ensure that target wallet providers support the necessary functionality. If you are interested in getting early access or learning more, please reach out to us at sales@reown.com.
 </Note>
 
 ## Demo

--- a/appkit/react-native/core/siwe.mdx
+++ b/appkit/react-native/core/siwe.mdx
@@ -1,8 +1,7 @@
 ---
-title: One-Click Auth / SIWE
+title: Sign In With Ethereum
+sidebarTitle: One-Click Auth (SIWE)
 ---
-
-# Sign In With Ethereum
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a form of authentication that enables users to control their digital identity with their Ethereum account.
 SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).

--- a/appkit/react/core/siwe.mdx
+++ b/appkit/react/core/siwe.mdx
@@ -1,5 +1,6 @@
 ---
-title: One-Click Auth / SIWE
+title: Sign In With Ethereum
+sidebarTitle: One-Click Auth (SIWE)
 ---
 
 import SiweCode from "/snippets/appkit/shared/siwe/code.mdx";

--- a/appkit/unity/core/siwe.mdx
+++ b/appkit/unity/core/siwe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sign-In With Ethereum
-sidebarTitle: One-Click Auth / SIWE
+sidebarTitle: One-Click Auth (SIWE)
 ---
 
 AppKit provides a simple solution for integrating with "Sign-In With Ethereum" (SIWE), a new form of authentication that

--- a/appkit/unity/core/socials.mdx
+++ b/appkit/unity/core/socials.mdx
@@ -1,9 +1,6 @@
 ---
-sidebarTitle: Email & Socials
 title: Email & Social Wallets
 ---
-
-# Email & Social Wallets
 
 AppKit enables passwordless Web3 onboarding and authentication, allowing your users interact with your application by creating a non-custodial wallet with just their emails or social accounts.
 

--- a/appkit/vue/core/siwe.mdx
+++ b/appkit/vue/core/siwe.mdx
@@ -1,11 +1,10 @@
 ---
-title: One-Click Auth / SIWE
+title: Sign In With Ethereum
+sidebarTitle: One-Click Auth (SIWE)
 ---
 
 import SiweCode from "/snippets/appkit/shared/siwe/code.mdx";
 import SiweParams from "/snippets/appkit/shared/siwe/parameters.mdx";
-
-# Sign In With Ethereum
 
 AppKit provides a simple solution for integrating with "Sign In With Ethereum" (SIWE), a new form of authentication that enables users to control their digital identity with their Ethereum account.
 SIWE is a standard also known as [EIP-4361](https://docs.login.xyz/general-information/siwe-overview/eip-4361).

--- a/docs.json
+++ b/docs.json
@@ -790,8 +790,13 @@
                   "appkit/ios/core/usage",
                   "appkit/ios/core/options",
                   "appkit/ios/core/actions",
-                  "appkit/ios/core/one-click-auth",
                   "appkit/ios/core/custom-chains"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/ios/core/one-click-auth"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -813,10 +813,15 @@
                   "appkit/unity/core/options",
                   "appkit/unity/core/actions",
                   "appkit/unity/core/events",
-                  "appkit/unity/core/siwe",
                   "appkit/unity/core/customization",
-                  "appkit/unity/core/socials",
                   "appkit/unity/core/smart-accounts"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/unity/core/socials",
+                  "appkit/unity/core/siwe"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -658,12 +658,17 @@
                   "appkit/react-native/core/options",
                   "appkit/react-native/core/hooks",
                   "appkit/react-native/core/components",
-                  "appkit/react-native/core/email",
                   "appkit/react-native/core/smart-accounts",
-                  "appkit/react-native/core/siwe",
                   "appkit/react-native/core/link-mode",
                   "appkit/react-native/core/theming",
                   "appkit/react-native/core/resources"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/react-native/core/email",
+                  "appkit/react-native/core/siwe"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -757,9 +757,14 @@
                   "appkit/android/core/usage",
                   "appkit/android/core/options",
                   "appkit/android/core/actions",
-                  "appkit/android/core/one-click-auth",
                   "appkit/android/core/components",
                   "appkit/android/core/theming"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/android/core/one-click-auth"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -312,15 +312,20 @@
                   "appkit/react/core/hooks",
                   "appkit/react/core/options",
                   "appkit/react/core/components",
-                  "appkit/react/core/socials",
                   "appkit/react/core/smart-accounts",
                   "appkit/react/core/custom-connectors",
                   "appkit/react/core/custom-networks",
-                  "appkit/react/core/siwe",
-                  "appkit/react/core/siwx",
                   "appkit/react/core/multichain",
                   "appkit/react/core/theming",
                   "appkit/react/core/resources"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/react/core/socials",
+                  "appkit/react/core/siwe",
+                  "appkit/react/core/siwx"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -486,15 +486,20 @@
                   "appkit/vue/core/composables",
                   "appkit/vue/core/options",
                   "appkit/vue/core/components",
-                  "appkit/vue/core/socials",
                   "appkit/vue/core/smart-accounts",
                   "appkit/vue/core/custom-connectors",
                   "appkit/vue/core/custom-networks",
-                  "appkit/vue/core/siwe",
-                  "appkit/vue/core/siwx",
                   "appkit/vue/core/multichain",
                   "appkit/vue/core/theming",
                   "appkit/vue/core/resources"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/vue/core/socials",
+                  "appkit/vue/core/siwe",
+                  "appkit/vue/core/siwx"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -572,15 +572,20 @@
                   "appkit/javascript/core/actions",
                   "appkit/javascript/core/options",
                   "appkit/javascript/core/components",
-                  "appkit/javascript/core/socials",
                   "appkit/javascript/core/smart-accounts",
                   "appkit/javascript/core/custom-connectors",
                   "appkit/javascript/core/custom-networks",
-                  "appkit/javascript/core/siwe",
-                  "appkit/javascript/core/siwx",
                   "appkit/javascript/core/multichain",
                   "appkit/javascript/core/theming",
                   "appkit/javascript/core/resources"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/javascript/core/socials",
+                  "appkit/javascript/core/siwe",
+                  "appkit/javascript/core/siwx"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -720,13 +720,18 @@
                   "appkit/flutter/core/installation",
                   "appkit/flutter/core/usage",
                   "appkit/flutter/core/options",
-                  "appkit/flutter/core/email",
-                  "appkit/flutter/core/siwe",
                   "appkit/flutter/core/link-mode",
                   "appkit/flutter/core/actions",
                   "appkit/flutter/core/events",
                   "appkit/flutter/core/theming",
                   "appkit/flutter/core/custom-chains"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/flutter/core/email",
+                  "appkit/flutter/core/siwe"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -399,15 +399,20 @@
                   "appkit/next/core/hooks",
                   "appkit/next/core/options",
                   "appkit/next/core/components",
-                  "appkit/next/core/socials",
                   "appkit/next/core/smart-accounts",
                   "appkit/next/core/custom-connectors",
                   "appkit/next/core/custom-networks",
-                  "appkit/next/core/siwe",
-                  "appkit/next/core/siwx",
                   "appkit/next/core/multichain",
                   "appkit/next/core/theming",
                   "appkit/next/core/resources"
+                ]
+              },
+              {
+                "group": "Authentication",
+                "pages": [
+                  "appkit/next/core/socials",
+                  "appkit/next/core/siwe",
+                  "appkit/next/core/siwx"
                 ]
               },
               {


### PR DESCRIPTION
## Description

This PR does the following:
1. Updates the redirect links for network specific AppKit installation docs to be handled correctly for Bitcoin and Solana
2. Adds "Authentication" section to all of the AppKit's technical docs. 
3. Updates inconsistent sidebar title for One Click Auth.
4. Adds info about how wallets should support `wallet_checkout` for one-click checkout to work.

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.