### PR TITLE
Docs Update: Updating old Cloud links to point to the new Cloud Dashboard

### DIFF
--- a/advanced/api/core/pairing.mdx
+++ b/advanced/api/core/pairing.mdx
@@ -70,14 +70,14 @@ implementation("com.walletconnect:android-core:release_version")
 
 #### Project set up
 
-To use initialize RelayClient properly you will need a projectId. Go to https://cloud.reown.com/app, register your project and get projectId.
+To use initialize RelayClient properly you will need a projectId. Go to https://dashboard.reown.com/app, register your project and get projectId.
 
 #### CoreClient initialization
 
 Before using any of the WalletConnect Kotlin SDKs, it is necessary to initialize the CoreClient. The initialization of CoreClient must always happen in the Android Application class. Provide the projectId generated in the Reown Cloud, the WebSocket URL, choose the connection type, and pass the application class. You can also pass your own Relay instance using the `RelayConnectionInterface`.
 
 ```kotlin
-val projectId = "" //Get Project ID at https://cloud.reown.com/
+val projectId = "" //Get Project ID at https://dashboard.reown.com/
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val application = //Android Application level class
 [Optional] val optionalRelay: RelayConnectionInterface? = /*implement interface*/
@@ -211,7 +211,7 @@ https://github.com/VolodymyrBS/WebGLThreadingPatcher.git
 #### Initialization
 
 1. Fill in the Project ID and Metadata fields in the `Assets/WalletConnectUnity/Resources/WalletConnectProjectConfig` asset.
-   - If you don’t have a Project ID, you can create one at [Reown Cloud](https://cloud.reown.com).
+   - If you don’t have a Project ID, you can create one at [Reown Cloud](https://dashboard.reown.com).
    - The `Redirect` fields are optional. They are used to redirect the user back to your app after they approve or reject the session.
 2. Initialize `WalletConnect` and get reference to the instance of `Core`:
 

--- a/advanced/api/notify/usage.mdx
+++ b/advanced/api/notify/usage.mdx
@@ -544,7 +544,7 @@ The Notify client is responsible for creating and maintaining subscriptions. To 
 `NotifyClient` should be initialized in the Application class.
 
 ```kotlin
-val projectId = "" // Get Project ID at https://cloud.reown.com/
+val projectId = "" // Get Project ID at https://dashboard.reown.com/
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Wallet Name",

--- a/advanced/api/sign/dapp-usage.mdx
+++ b/advanced/api/sign/dapp-usage.mdx
@@ -398,7 +398,7 @@ Above method will extend a user's session to a week.
 #### **Initialization**
 
 ```kotlin
-val projectId = "" // Get Project ID at https://cloud.reown.com/
+val projectId = "" // Get Project ID at https://dashboard.reown.com/
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Dapp Name",
@@ -999,7 +999,7 @@ WalletConnectUnity is a wrapper for WalletConnectSharp. It simplifies managing a
 To use WalletConnectUnity in your project:
 
 1. Fill in the Project ID and Metadata fields in the `Assets/WalletConnectUnity/Resources/WalletConnectProjectConfig` asset.
-   - If you don’t have a Project ID, you can create one at [Reown Cloud](https://cloud.reown.com).
+   - If you don’t have a Project ID, you can create one at [Reown Cloud Dashboard](https://dashboard.reown.com).
    - The `Redirect` fields are optional. They are used to redirect the user back to your app after they approve or reject the session.
 2. Initialize `WalletConnect` and connect the wallet:
 

--- a/advanced/api/sign/wallet-usage.mdx
+++ b/advanced/api/sign/wallet-usage.mdx
@@ -391,7 +391,7 @@ Session proposal is a handshake sent by a dapp and it's purpose is to define a s
 
 `VerifyContext` provides a domain verification information about `Session.Proposal` and `Request`. It consists of origin of a Dapp from where the request has been sent, validation enum that says whether origin is **unknown**, **valid** or **invalid** and verify URL server.
 
-To enable or disable verification find the **Verify SDK** toggle in your project [cloud](https://cloud.reown.com).
+To enable or disable verification find the **Verify SDK** toggle in your project [dashboard](https://dashboard.reown.com).
 
 ```swift
 public struct VerifyContext: Equatable, Hashable {
@@ -694,7 +694,7 @@ try await Sign.instance.rejectSession(requestId: requestId)
 #### **Initialization**
 
 ```kotlin
-val projectId = "" // Get Project ID at https://cloud.reown.com/
+val projectId = "" // Get Project ID at https://dashboard.reown.com/
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
 val appMetaData = Core.Model.AppMetaData(
     name = "Wallet Name",

--- a/advanced/multichain/polkadot/dapp-integration-guide.mdx
+++ b/advanced/multichain/polkadot/dapp-integration-guide.mdx
@@ -14,7 +14,7 @@ title: "Dapp Integration Guide"
 
 # WalletConnect Code/Component Setup
 
-1. **One time step**: Generate a unique `projectId` by visiting and creating your project’s profile on WalletConnect’s project dashboard at: https://cloud.reown.com/.
+1. **One time step**: Generate a unique `projectId` by visiting and creating your project’s profile on WalletConnect’s project dashboard at: https://dashboard.reown.com/.
 
 2. Import `UniversalProvider` and `{ WalletConnectModal }` from `@walletconnect/universal-provider` and `@walletconnect/modal` respectively.
 

--- a/advanced/multichain/polkadot/wallet-integration-guide.mdx
+++ b/advanced/multichain/polkadot/wallet-integration-guide.mdx
@@ -13,7 +13,7 @@ title: "Wallet Integration Guide"
 ---
 
 1. **Getting Started:** Generate a unique `projectId` by visiting and creating your project's profile on WalletConnect's project dashboard at:
-   - `https://cloud.reown.com/`
+   - `https://dashboard.reown.com/`
 
 # WalletConnect Code/Component Setup
 

--- a/advanced/providers/ethereum.mdx
+++ b/advanced/providers/ethereum.mdx
@@ -69,7 +69,7 @@ The Ethereum Provider's `init` method takes the following parameters:
 
 | Value             | Description                                                                                                                                               | Type                          | Required |
 |------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|----------|
-| **projectId**    | Your project ID obtained from Reown Cloud: [https://cloud.reown.com/](https://cloud.reown.com/)                                                           | `string`                     | true     |
+| **projectId**    | Your project ID obtained from Reown Cloud: [https://dashboard.reown.com/](https://dashboard.reown.com/)                                                           | `string`                     | true     |
 | **optionalChains** | An array of the chain IDs you want to support. It is highly recommended to use "optionalChains" over "chains" for multi-chain dapps, ensuring compatibility with Smart Contract Wallets. | `number[]`                   | false    |
 | **optionalMethods** | The Ethereum methods you want to support and send in the session proposal under the "optionalNamespaces" scope. If undefined, it defaults to all EIP-1193 compatible methods. | `string[]`                   | false    |
 | **optionalEvents**  | The Ethereum events you want to support and send in the session proposal under the "optionalNamespaces" scope. If undefined, it defaults to all EIP-1193 compatible events. | `string[]`                   | false    |
@@ -110,7 +110,7 @@ Upon integrating the below code, you will be able to see the QRModal on your Web
 import { createAppKit } from "@reown/appkit";
 import { mainnet, arbitrum, sepolia } from "@reown/appkit/networks";
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create the AppKit instance

--- a/advanced/providers/solana-adapter.mdx
+++ b/advanced/providers/solana-adapter.mdx
@@ -25,7 +25,7 @@ The WalletConnect Solana Adapter allows you to integrate the WalletConnect proto
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/advanced/push-server.mdx
+++ b/advanced/push-server.mdx
@@ -14,7 +14,7 @@ It is recommended that you use Reown Cloud for simplicity and ease of integratio
 
 ## Setup in Reown Cloud
 
-1. Create a Project in the Cloud App. Go to [Reown Cloud](https://cloud.reown.com/) and sign up for an account.
+1. Create a Project in the Cloud App. Go to [Reown Cloud](https://dashboard.reown.com/) and sign up for an account.
 
 2. To get your project's Push URL, from the Cloud App, go into the settings tab and click on `Create Push URL`.
 <Frame>

--- a/advanced/walletconnectmodal/options.mdx
+++ b/advanced/walletconnectmodal/options.mdx
@@ -84,7 +84,7 @@ new WalletConnectModal({
 
 #### projectId (required)
 
-Your project’s unique identifier that can be obtained at [cloud.reown.com](https://cloud.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `undefined`.
+Your project’s unique identifier that can be obtained at [dashboard.reown.com](https://cloud.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `undefined`.
 
 ```ts
 projectId: string;

--- a/advanced/walletconnectmodal/options.mdx
+++ b/advanced/walletconnectmodal/options.mdx
@@ -84,7 +84,7 @@ new WalletConnectModal({
 
 #### projectId (required)
 
-Your project’s unique identifier that can be obtained at [dashboard.reown.com](https://cloud.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `undefined`.
+Your project’s unique identifier that can be obtained at [dashboard.reown.com](https://dashboard.reown.com). Enables following functionalities within WalletConnectModal: wallet and chain logos, optional WalletConnect RPC, support for all v2 wallets from [WalletGuide](https://walletguide.walletconnect.network/). Defaults to `undefined`.
 
 ```ts
 projectId: string;

--- a/advanced/walletconnectmodal/usage.mdx
+++ b/advanced/walletconnectmodal/usage.mdx
@@ -111,7 +111,7 @@ or you can change them later by calling `WalletConnectModal.set(sessionParams: S
 
 ```kotlin
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
-val projectId = "" // Get Project ID at https://cloud.reown.com/
+val projectId = "" // Get Project ID at https://dashboard.reown.com/
 val appMetaData = Core.Model.AppMetaData(
     name = "Kotlin.WalletConnectModal",
     description = "Kotlin WalletConnectModal Implementation",
@@ -276,7 +276,7 @@ This is a bug in the wallets, not this package.
 
 <Tab title="React Native">
 
-Start by importing `@walletconnect/react-native-compat` at the top of your app. Then import the WalletConnect Modal package, replace `YOUR_PROJECT_ID` with your [Reown Cloud](https://cloud.reown.com/sign-in) Project ID and add your Project's info in `providerMetadata`
+Start by importing `@walletconnect/react-native-compat` at the top of your app. Then import the WalletConnect Modal package, replace `YOUR_PROJECT_ID` with your [Reown Cloud](https://dashboard.reown.com/sign-in) Project ID and add your Project's info in `providerMetadata`
 
 ```tsx
 import "@walletconnect/react-native-compat";
@@ -312,7 +312,7 @@ function App() {
 <Tab title="Unity">
 
 1. Fill in the Project ID and Metadata fields in the `Assets/WalletConnectUnity/Resources/WalletConnectProjectConfig` asset.
-   - If you don’t have a Project ID, you can create one at [Reown Cloud](https://cloud.reown.com).
+   - If you don’t have a Project ID, you can create one at [Reown Cloud](https://dashboard.reown.com).
    - The `Redirect` fields are optional. They are used to redirect the user back to your app after they approve or reject the session.
 2. Add `WalletConnectModal` prefab from `WalletConnectUnity Modal` package to the first scene in your game.
 

--- a/appkit/android/core/usage.mdx
+++ b/appkit/android/core/usage.mdx
@@ -10,7 +10,7 @@ title: Usage
 
 ```kotlin
 val connectionType = ConnectionType.AUTOMATIC or ConnectionType.MANUAL
-val projectId = "" // Get Project ID at https://cloud.reown.com/
+val projectId = "" // Get Project ID at https://dashboard.reown.com/
 val appMetaData = Core.Model.AppMetaData(
     name = "Kotlin.AppKit",
     description = "Kotlin AppKit Implementation",

--- a/appkit/faq.mdx
+++ b/appkit/faq.mdx
@@ -17,7 +17,7 @@ This FAQ section covers common questions and solutions for using AppKit. The que
 
     This error typically occurs when the `projectId` is not configured correctly. To resolve this:
 
-    1. Create a valid project ID at [https://cloud.reown.com/](https://cloud.reown.com/)
+    1. Create a valid project ID at [https://dashboard.reown.com/](https://dashboard.reown.com/)
     2. Add it to your AppKit configuration:
 
     ```javascript

--- a/appkit/flutter/core/email.mdx
+++ b/appkit/flutter/core/email.mdx
@@ -16,7 +16,7 @@ AppKit enables passwordless Web3 onboarding and authentication, allowing your us
 <Warning>
 Remember to whitelist your dapp's iOS's bundleId and Android's packageName in your cloud configuration.
 
-1. LogIn into https://cloud.reown.com
+1. LogIn into https://dashboard.reown.com
 2. Open Dashboard and scroll down to _Mobile Application IDs_ menu
 3. Add your iOS Bundle ID and your Android Package Name
 </Warning>

--- a/appkit/flutter/core/link-mode.mdx
+++ b/appkit/flutter/core/link-mode.mdx
@@ -25,7 +25,7 @@ Check out [SIWE basic example](./siwe#basic-usage-example) to try it out.
 
 ### How to enable it:
 
-1. Add a Universal Link for your wallet in the **Explorer** tab of your [**Cloud project configuration**](https://cloud.reown.com/sign-in), under the **Mobile Linking** section
+1. Add a Universal Link for your wallet in the **Explorer** tab of your [**Cloud project configuration**](https://dashboard.reown.com/sign-in), under the **Mobile Linking** section
 
 2. Configure your `PairingMetadata`'s `redirect:` object with that Universal Link
 

--- a/appkit/flutter/core/options.mdx
+++ b/appkit/flutter/core/options.mdx
@@ -43,7 +43,7 @@ final _appKitModal = ReownAppKitModal(
 
 ### enableAnalytics:
 
-Enable analytics to get more insights on your users activity within your [Reown Cloud's dashboard](https://cloud.reown.com)
+Enable analytics to get more insights on your users activity within your [Reown Cloud's dashboard](https://dashboard.reown.com)
 
 ### siweConfig:
 

--- a/appkit/javascript/core/installation.mdx
+++ b/appkit/javascript/core/installation.mdx
@@ -179,7 +179,7 @@ pnpm add @reown/appkit @walletconnect/universal-provider ethers
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/appkit/javascript/notifications/backend-integration.mdx
+++ b/appkit/javascript/notifications/backend-integration.mdx
@@ -13,7 +13,7 @@ We recommend testing notifications with the [Web3Inbox.com app](https://app.web3
 
 To send notifications and access all subscriber information for your dapp, you will need your Notify API Secret and project ID.
 
-You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://cloud.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
+You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://dashboard.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
 
 ## Sending notifications
 

--- a/appkit/javascript/notifications/cloud-sending.mdx
+++ b/appkit/javascript/notifications/cloud-sending.mdx
@@ -2,11 +2,11 @@
 title: Sending with Cloud
 ---
 
-You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
+You can send notifications to subscribed users easily in [Reown Cloud Dashboard](https://dashboard.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.
 
-To send notifications, you can use the utility provided in [Reown Cloud](https://cloud.reown.com) under the Notify API section:
+To send notifications, you can use the utility provided in [Reown Cloud Dashboard](https://dashboard.reown.com) under the Notify API section:
 
 1. In the APIs tab of your project, navigate to the Notify API section. You should see a banner with a link to the Send Notification playground.
 

--- a/appkit/javascript/notifications/cloud-setup.mdx
+++ b/appkit/javascript/notifications/cloud-setup.mdx
@@ -12,9 +12,9 @@ For a quick start to experiment with, you can try the [web3inbox template](https
 
 ## Domain to use
 
-It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud](https://cloud.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
+It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud Dashboard](https://dashboard.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
 
-You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud](https://cloud.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
+You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud Dashboard](https://dashboard.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
@@ -47,7 +47,7 @@ Notification types are configured with a name, description, and icon which allow
 
 ### Navigating to Notify API section
 
-In [Reown Cloud](https://cloud.reown.com), navigate to the APIs tab of your project.
+In [Reown Cloud Dashboard](https://dashboard.reown.com), navigate to the APIs tab of your project.
 
 <Frame>
   <img src="/images/w3i/1.png" />

--- a/appkit/migration/from-anza-adapter-react.mdx
+++ b/appkit/migration/from-anza-adapter-react.mdx
@@ -10,7 +10,7 @@ Follow the steps below to migrate from the Starter Pack of Anza Adapter to AppKi
 
 ### a. Create a project in Reown Cloud
 
-- Create a new project on [Reown Cloud](https://cloud.reown.com) and obtain a new project ID.
+- Create a new project on [Reown Cloud Dashboard](https://dashboard.reown.com) and obtain a new project ID.
 
 ### b. Uninstall old packages and install the AppKit packages:
 
@@ -64,7 +64,7 @@ Update the code:
 
 ```tsx
 
-// 1. Get projectId at https://cloud.reown.com
+// 1. Get projectId at https://dashboard.reown.com
 const projectId = import.meta.env.VITE_PROJECT_ID
 if (!projectId) throw new Error('Project ID is undefined')
 

--- a/appkit/migration/from-connectkit-next.mdx
+++ b/appkit/migration/from-connectkit-next.mdx
@@ -13,7 +13,7 @@ To migrate from ConnectKit to Reown AppKit, please follow the steps below.
 
 ## Step 1. Create a project in Reown Cloud
 
-- Create a new project on [Reown Cloud](https://cloud.reown.com) and obtain a new project ID.
+- Create a new project on [Reown Cloud](https://dashboard.reown.com) and obtain a new project ID.
 
 ## Step 2. Install & uninstall libraries
 
@@ -61,7 +61,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 - );
 
 // If you were already using WalletConnect with ConnectKit, you can use the same projectId.
-// If not, then get projectId from https://cloud.reown.com
+// If not, then get projectId from https://dashboard.reown.com
 + export const projectId = "YOUR_PROJECT_ID";
 
 //Set up the Wagmi Adapter (Config)

--- a/appkit/migration/from-privy-next.mdx
+++ b/appkit/migration/from-privy-next.mdx
@@ -12,7 +12,7 @@ Follow the steps below to migrate from a default Privy project (using Next.js Pa
 
 ### Step 1. Create a project in Reown Cloud
 
-- Go to [Reown Cloud](http://cloud.reown.com).
+- Go to [Reown Cloud Dashboard](http://dashboard.reown.com).
 - Create a new project and copy your Project ID — you'll need it later.
 
 ### Step 2. Install & uninstall libraries

--- a/appkit/migration/from-rainbowkit-next.mdx
+++ b/appkit/migration/from-rainbowkit-next.mdx
@@ -8,7 +8,7 @@ Follow the steps below to migrate from the default RainbowKit project using Next
 
 ### Step 1. Create a project in Reown Cloud
 
-- Create a new project on [Reown Cloud](https://cloud.reown.com) and obtain a new project ID.
+- Create a new project on [Reown Cloud Dashboard](https://dashboard.reown.com) and obtain a new project ID.
 
 ### Step 2. Install & uninstall libraries
 

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -216,7 +216,7 @@ pnpm add @reown/appkit @walletconnect/universal-provider
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud Dashboard at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/appkit/next/core/siwe.mdx
+++ b/appkit/next/core/siwe.mdx
@@ -415,7 +415,7 @@ const nextAuthSecret = process.env.NEXTAUTH_SECRET;
 if (!nextAuthSecret) {
   throw new Error("NEXTAUTH_SECRET is not set");
 }
-// Get your projectId on https://cloud.reown.com
+// Get your projectId on https://dashboard.reown.com
 const projectId = process.env.NEXT_PUBLIC_PROJECT_ID;
 if (!projectId) {
   throw new Error("NEXT_PUBLIC_PROJECT_ID is not set");

--- a/appkit/next/notifications/backend-integration.mdx
+++ b/appkit/next/notifications/backend-integration.mdx
@@ -13,7 +13,7 @@ We recommend testing notifications with the [Web3Inbox.com app](https://app.web3
 
 To send notifications and access all subscriber information for your dapp, you will need your Notify API Secret and project ID.
 
-You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://cloud.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
+You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud Dashboard](https://dashboard.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
 
 ## Sending notifications
 

--- a/appkit/next/notifications/cloud-sending.mdx
+++ b/appkit/next/notifications/cloud-sending.mdx
@@ -2,11 +2,11 @@
 title: Sending with Cloud
 ---
 
-You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
+You can send notifications to subscribed users easily in [Reown Cloud Dashboard](https://dashboard.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.
 
-To send notifications, you can use the utility provided in [Reown Cloud](https://cloud.reown.com) under the Notify API section:
+To send notifications, you can use the utility provided in [Reown Cloud Dashboard](https://dashboard.reown.com) under the Notify API section:
 
 1. In the APIs tab of your project, navigate to the Notify API section. You should see a banner with a link to the Send Notification playground.
 

--- a/appkit/next/notifications/cloud-setup.mdx
+++ b/appkit/next/notifications/cloud-setup.mdx
@@ -12,9 +12,9 @@ For a quick start to experiment with, you can try the [web3inbox template](https
 
 ## Domain to use
 
-It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud](https://cloud.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
+It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud Dashboard](https://dashboard.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
 
-You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud](https://cloud.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
+You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud Dashboard](https://dashboard.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
@@ -47,7 +47,7 @@ Notification types are configured with a name, description, and icon which allow
 
 ### Navigating to Notify API section
 
-In [Reown Cloud](https://cloud.reown.com), navigate to the APIs tab of your project.
+In [Reown Cloud Dashboard](https://dashboard.reown.com), navigate to the APIs tab of your project.
 
 <Frame>
   <img src="/images/w3i/1.png" />

--- a/appkit/nuxt/core/installation.mdx
+++ b/appkit/nuxt/core/installation.mdx
@@ -124,7 +124,7 @@ pnpm add @reown/appkit @reown/appkit-adapter-bitcoin
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud Dashboard at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/appkit/react-native/core/email.mdx
+++ b/appkit/react-native/core/email.mdx
@@ -19,7 +19,7 @@ Due to Safari’s strict third-party cookie policies, the SDK is not preserving 
 
 <Tab title="Wagmi">
    ### Update your Cloud settings
-   1. Go to your [Cloud](https://cloud.reown.com) project
+   1. Go to your [Cloud Dashboard](https://dashboard.reown.com) project
    2. Open Dashboard and scroll down to Mobile Application IDs menu
    3. Add your iOS Bundle ID and/or your Android Package Name
    * Changes might take some minutes to impact
@@ -28,7 +28,7 @@ Due to Safari’s strict third-party cookie policies, the SDK is not preserving 
 </Tab>
 
 <Tab title="Ethers">
-  ### Update your Cloud settings 1. Go to your [Cloud](https://cloud.reown.com)
+  ### Update your Cloud settings 1. Go to your [Cloud Dashboard](https://dashboard.reown.com)
   project 2. Open Dashboard and scroll down to Mobile Application IDs menu 3.
   Add your iOS Bundle ID and/or your Android Package Name * Changes might take
   some minutes to impact

--- a/appkit/react-native/core/link-mode.mdx
+++ b/appkit/react-native/core/link-mode.mdx
@@ -15,7 +15,7 @@ AppKit Link Mode is a low latency mechanism for transporting One-Click Auth requ
 
 ### How to enable it:
 
-To support link mode add a universal link for your dapp in Cloud project configuration [dashboard](https://cloud.reown.com/sign-in), configure your Metadata with a valid universal link and set the `linkMode` property to `true`:
+To support link mode add a universal link for your dapp in Cloud project configuration [dashboard](https://dashboard.reown.com/sign-in), configure your Metadata with a valid universal link and set the `linkMode` property to `true`:
 
 ```ts {8,9}
 const metadata = {

--- a/appkit/react-native/core/options.mdx
+++ b/appkit/react-native/core/options.mdx
@@ -223,7 +223,7 @@ createAppKit({
 
 ## enableAnalytics
 
-Enable analytics to get more insights on your users activity within your [Reown Cloud's dashboard](https://cloud.reown.com)
+Enable analytics to get more insights on your users activity within your [Reown Cloud dashboard](https://dashboard.reown.com)
 
 ```ts
 createAppKit({

--- a/appkit/react-native/notifications/backend-integration.mdx
+++ b/appkit/react-native/notifications/backend-integration.mdx
@@ -13,7 +13,7 @@ We recommend testing notifications with the [Web3Inbox.com app](https://app.web3
 
 To send notifications and access all subscriber information for your dapp, you will need your Notify API Secret and project ID.
 
-You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://cloud.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
+You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud Dashboard](https://dashboard.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
 
 ## Sending notifications
 

--- a/appkit/react-native/notifications/cloud-sending.mdx
+++ b/appkit/react-native/notifications/cloud-sending.mdx
@@ -2,11 +2,11 @@
 title: Sending with Cloud
 ---
 
-You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
+You can send notifications to subscribed users easily in [Reown Cloud Dashboard](https://dashboard.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.
 
-To send notifications, you can use the utility provided in [Reown Cloud](https://cloud.reown.com) under the Notify API section:
+To send notifications, you can use the utility provided in [Reown Cloud Dashboard](https://dashboard.reown.com) under the Notify API section:
 
 1. In the APIs tab of your project, navigate to the Notify API section. You should see a banner with a link to the Send Notification playground.
 

--- a/appkit/react-native/notifications/cloud-setup.mdx
+++ b/appkit/react-native/notifications/cloud-setup.mdx
@@ -12,9 +12,9 @@ For a quick start to experiment with, you can try the [web3inbox template](https
 
 ## Domain to use
 
-It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud](https://cloud.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
+It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud Dashboard](https://dashboard.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
 
-You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud](https://cloud.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
+You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud Dashboard](https://dashboard.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
@@ -47,7 +47,7 @@ Notification types are configured with a name, description, and icon which allow
 
 ### Navigating to Notify API section
 
-In [Reown Cloud](https://cloud.reown.com), navigate to the APIs tab of your project.
+In [Reown Cloud Dashboard](https://dashboard.reown.com), navigate to the APIs tab of your project.
 
 <Frame>
   <img src="/images/w3i/1.png" />

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -219,7 +219,7 @@ pnpm add @reown/appkit @walletconnect/universal-provider @reown/appkit-common et
 
 ## Cloud Configuration
 
-Create a new project on reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud Dashboard at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/appkit/react/notifications/backend-integration.mdx
+++ b/appkit/react/notifications/backend-integration.mdx
@@ -13,7 +13,7 @@ We recommend testing notifications with the [Web3Inbox.com app](https://app.web3
 
 To send notifications and access all subscriber information for your dapp, you will need your Notify API Secret and project ID.
 
-You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://cloud.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
+You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud Dashboard](https://dashboard.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
 
 ## Sending notifications
 

--- a/appkit/react/notifications/cloud-sending.mdx
+++ b/appkit/react/notifications/cloud-sending.mdx
@@ -2,11 +2,11 @@
 title: Sending with Cloud
 ---
 
-You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
+You can send notifications to subscribed users easily in [Reown Cloud Dashboard](https://dashboard.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.
 
-To send notifications, you can use the utility provided in [Reown Cloud](https://cloud.reown.com) under the Notify API section:
+To send notifications, you can use the utility provided in [Reown Cloud Dashboard](https://dashboard.reown.com) under the Notify API section:
 
 1. In the APIs tab of your project, navigate to the Notify API section. You should see a banner with a link to the Send Notification playground.
 

--- a/appkit/react/notifications/cloud-setup.mdx
+++ b/appkit/react/notifications/cloud-setup.mdx
@@ -12,9 +12,9 @@ For a quick start to experiment with, you can try the [web3inbox template](https
 
 ## Domain to use
 
-It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud](https://cloud.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
+It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud Dashboard](https://dashboard.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
 
-You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud](https://cloud.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
+You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud Dashboard](https://dashboard.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
@@ -47,7 +47,7 @@ Notification types are configured with a name, description, and icon which allow
 
 ### Navigating to Notify API section
 
-In [Reown Cloud](https://cloud.reown.com), navigate to the APIs tab of your project.
+In [Reown Cloud Dashboard](https://dashboard.reown.com), navigate to the APIs tab of your project.
 
 <Frame>
   <img src="/images/w3i/1.png" />

--- a/appkit/recipes/EVM-smart-contract-interaction.mdx
+++ b/appkit/recipes/EVM-smart-contract-interaction.mdx
@@ -16,7 +16,7 @@ Let’s dive in!
 
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 
 ## Final project
 <Card title="Appkit Wagmi Example with smart contract interactions" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-wagmi">

--- a/appkit/recipes/bitcoin-send-transaction.mdx
+++ b/appkit/recipes/bitcoin-send-transaction.mdx
@@ -21,7 +21,7 @@ Let's dive in!
 
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 
 ## Final project
 <Card title="Appkit Example for Interacting with the Bitcoin Blockchain" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-bitcoin">

--- a/appkit/recipes/ethers-send-transaction.mdx
+++ b/appkit/recipes/ethers-send-transaction.mdx
@@ -23,7 +23,7 @@ Let’s dive in!
 
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 
 ## Final project
 <Card title="Appkit Ethers Example with blockchain interactions" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-ethers">

--- a/appkit/recipes/smart-sessions.mdx
+++ b/appkit/recipes/smart-sessions.mdx
@@ -8,7 +8,7 @@ Learn how to use Reown AppKit with Smart Sessions to grant permission to delegat
 ## Prerequisites
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- A new project Id obtained from Reown Cloud at https://cloud.reown.com
+- A new project Id obtained from Reown Cloud Dashboard at https://dashboard.reown.com
 - A wallet with the private key in order to sign Transactions
 
 ## Final Project

--- a/appkit/recipes/solana-send-transaction.mdx
+++ b/appkit/recipes/solana-send-transaction.mdx
@@ -23,7 +23,7 @@ Let's dive in!
 
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 
 ## Final project
 <Card title="Appkit Example for Interacting with the Solana Blockchain" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-solana">

--- a/appkit/recipes/sponsoring-first-transaction.mdx
+++ b/appkit/recipes/sponsoring-first-transaction.mdx
@@ -23,7 +23,7 @@ Let's dive in!
 
 ## Prerequisites
 - A fundamental understanding of JavaScript and React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 - Since Gas Sponsorship is an early access feature, your projectId needs to be access listed. Please [contact us](https://reown.com/contact).
                             
 ## Part 1: Steps to Set up a policy
@@ -269,7 +269,7 @@ block explorer that supports searching by User Op Hashes like BlockScout
 
 
 ## Links
-- [Reown Cloud](https://cloud.reown.com)
+- [Reown Cloud Dashboard](https://dashboard.reown.com)
 - [Appkit lab](https://appkit-lab.reown.com/library/wagmi/)
 
 

--- a/appkit/recipes/tenderly-virtual-testnets.mdx
+++ b/appkit/recipes/tenderly-virtual-testnets.mdx
@@ -41,7 +41,7 @@ npm install @reown/appkit @reown/appkit-wagmi-adapter wagmi @tanstack/react-quer
 
 ### Create a new project on Reown Cloud
 
-Now, we need to get a project Id from Reown Cloud that we will use to set up AppKit with Wagmi config. Navigate to [cloud.reown.com](https://cloud.reown.com) and sign in. If you have not created an account yet, please do so before we proceed.
+Now, we need to get a project Id from Reown Cloud Dashboard that we will use to set up AppKit with Wagmi config. Navigate to [dashboard.reown.com](https://dashboard.reown.com) and sign in. If you have not created an account yet, please do so before we proceed.
 
 After you have logged in, please navigate to the “**Projects**” section of the Cloud and click on “**Create Project**”.
 <Frame>
@@ -156,7 +156,7 @@ import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import { mainnet, arbitrum } from "@reown/appkit/networks";
 import { vTestnet } from "@/app/tenderly.config";
 
-// Get projectId from https://cloud.reown.com
+// Get projectId from https://dashboard.reown.com
 export const projectId = process.env.NEXT_PUBLIC_PROJECT_ID;
 
 if (!projectId) {

--- a/appkit/recipes/travel-rule.mdx
+++ b/appkit/recipes/travel-rule.mdx
@@ -36,7 +36,7 @@ Here's a practical example:
 Before implementing SIWX for Travel Rule compliance, ensure you have:
 
 - AppKit installed and configured in your project following the [AppKit Next installation guide](https://docs.reown.com/appkit/next/core/installation)
-- A project ID from [Reown Cloud](https://cloud.reown.com)
+- A project ID from [Reown Cloud](https://dashboard.reown.com)
 
 ## Example Implementation
 

--- a/appkit/recipes/wagmi-send-transaction.mdx
+++ b/appkit/recipes/wagmi-send-transaction.mdx
@@ -23,7 +23,7 @@ Let’s dive in!
 
 - A fundamental understanding of JavaScript and React.
 - A minimal installation of AppKit in React.
-- Obtain a new project Id on Reown Cloud at https://cloud.reown.com
+- Obtain a new project Id on Reown Cloud Dashboard at https://dashboard.reown.com
 
 ## Final project
 <Card title="Appkit wagmi Example with blockchain interactions" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/react/react-wagmi">

--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -124,7 +124,7 @@ pnpm add @reown/appkit @reown/appkit-adapter-bitcoin
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud Dashboard at https://dashboard.reown.com and obtain a new project ID.
 
 <CloudBanner />
 

--- a/appkit/unity/core/installation.mdx
+++ b/appkit/unity/core/installation.mdx
@@ -78,7 +78,7 @@ await AppKit.InitializeAsync(
 ```
 
 - **projectId**: The project ID is a unique identifier for your project.
-  - If you don’t have a Project ID, you can create one at [Reown Cloud](https://cloud.reown.com).
+  - If you don’t have a Project ID, you can create one at [Reown Cloud Dashboard](https://dashboard.reown.com).
 - **name**: The project name is a human-readable name for your project.
 - **description**: The project description is a human-readable description for your project.
 - **url**: The project URL

--- a/appkit/unity/core/siwe.mdx
+++ b/appkit/unity/core/siwe.mdx
@@ -67,7 +67,7 @@ Add the SIWE configuration to `AppKitConfig`
 ```csharp {17}
 var appKitConfig = new AppKitConfig
 {
-    // Project ID from https://cloud.reown.com/
+    // Project ID from https://dashboard.reown.com/
     projectId = "MY_PROJECT_ID",
     metadata = new Metadata(
         "App Name",
@@ -177,7 +177,7 @@ Add the SIWE configuration to `AppKitConfig`
 ```csharp {17}
 var appKitConfig = new AppKitConfig
 {
-    // Project ID from https://cloud.reown.com/
+    // Project ID from https://dashboard.reown.com/
     projectId = "MY_PROJECT_ID",
     metadata = new Metadata(
         "App Name",

--- a/appkit/upgrade/appkitv2.mdx
+++ b/appkit/upgrade/appkitv2.mdx
@@ -190,7 +190,7 @@ import { mainnet } from 'viem/chains'
 Then create `wagmiConfig` using your own settings
 
 ```tsx
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Create wagmiConfig
@@ -363,7 +363,7 @@ import { coinbaseWallet, walletConnect, injected } from '@wagmi/connectors'
 Then create `wagmiConfig` using your own settings
 
 ```tsx
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Create wagmiConfig

--- a/appkit/vue/core/installation.mdx
+++ b/appkit/vue/core/installation.mdx
@@ -173,7 +173,7 @@ pnpm add @reown/appkit @reown/appkit-adapter-bitcoin
 
 ## Cloud Configuration
 
-Create a new project on Reown Cloud at https://cloud.reown.com and obtain a new project ID.
+Create a new project on Reown Cloud Dashboard at https://dashboard.reown.com and obtain a new project ID.
 
 ## Implementation
 

--- a/appkit/vue/notifications/backend-integration.mdx
+++ b/appkit/vue/notifications/backend-integration.mdx
@@ -13,7 +13,7 @@ We recommend testing notifications with the [Web3Inbox.com app](https://app.web3
 
 To send notifications and access all subscriber information for your dapp, you will need your Notify API Secret and project ID.
 
-You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud](https://cloud.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
+You can find the Notify API Secret under the Notify API section of the APIs tab of your project on [Reown Cloud Dashboard](https://dashboard.reown.com). Follow steps on the [Cloud Setup](cloud-setup) page to configure this. This secret allows publishing notifications to any account subscribed to your app, so should not be published and should only be used by your app backend.
 
 ## Sending notifications
 

--- a/appkit/vue/notifications/cloud-sending.mdx
+++ b/appkit/vue/notifications/cloud-sending.mdx
@@ -2,11 +2,11 @@
 title: Sending with Cloud
 ---
 
-You can send notifications to subscribed users easily in [Reown Cloud](https://cloud.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
+You can send notifications to subscribed users easily in [Reown Cloud Dashboard](https://dashboard.reown.com). Sending to users involves targeting particular [notification types](./cloud-setup#notification-types) who will receive your notification if they have not opted-out. You can specify a title and body for the notification, as well as a call-to-action link which users will be taken to when clicking on the notification.
 
 Users can subscribe to your app in [several places](overview#subscribing-and-receiving-notifications) including the [Web3Inbox.com app](https://app.web3inbox.com), in your app with our [frontend SDK](frontend-integration/usage), or in supporting wallets.
 
-To send notifications, you can use the utility provided in [Reown Cloud](https://cloud.reown.com) under the Notify API section:
+To send notifications, you can use the utility provided in [Reown Cloud Dashboard](https://dashboard.reown.com) under the Notify API section:
 
 1. In the APIs tab of your project, navigate to the Notify API section. You should see a banner with a link to the Send Notification playground.
 

--- a/appkit/vue/notifications/cloud-setup.mdx
+++ b/appkit/vue/notifications/cloud-setup.mdx
@@ -12,9 +12,9 @@ For a quick start to experiment with, you can try the [web3inbox template](https
 
 ## Domain to use
 
-It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud](https://cloud.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
+It is important to understand what domain you are using for your project as you are required to host a static file (the `did.json` file) on this domain before being able to use Notify API. The [Reown Cloud Dashboard](https://dashboard.reown.com) and clients receiving and managing your notifications use this file to authenticate that your domain is associated with the source of the notifications.
 
-You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud](https://cloud.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
+You can pick 1 domain and this is configured in the Dapp URL field of the Notify API section of the [Reown Cloud Dashboard](https://dashboard.reown.com). You may change your domain at any time, as long as you properly host the new `did.json` file there. Note that only one project may use a given domain at the same time.
 
 During development it is optional to use your production domain for testing. Instead, you can use a staging domain, or even a entirely separate domain e.g. Vercel test site. However, once you move to production you will need to update your domain to your production domain and host a new file there.
 
@@ -47,7 +47,7 @@ Notification types are configured with a name, description, and icon which allow
 
 ### Navigating to Notify API section
 
-In [Reown Cloud](https://cloud.reown.com), navigate to the APIs tab of your project.
+In [Reown Cloud Dashboard](https://dashboard.reown.com), navigate to the APIs tab of your project.
 
 <Frame>
   <img src="/images/w3i/1.png" />

--- a/appkit/vue/solana/about/implementation.mdx
+++ b/appkit/vue/solana/about/implementation.mdx
@@ -10,7 +10,7 @@ In your `App.vue` file set up the following configuration
   import { reconnect } from '@wagmi/core'
 
   // 1. Define constants
-  const projectId = process.env.VUE_APP_PROJECT_ID // get it from cloud.reown.com
+  const projectId = process.env.VUE_APP_PROJECT_ID // get it from dashboard.reown.com
 
   // 2. Create wagmiConfig
   const metadata = {

--- a/cloud/analytics.mdx
+++ b/cloud/analytics.mdx
@@ -6,7 +6,7 @@ title: Analytics
 
 To access Reown Analytics and explore these insightful features, follow these simple steps:
 
-1. Log In to your Cloud Account [here](https://cloud.reown.com/sign-in).
+1. Log In to your Cloud Dashboard account [here](https://dashboard.reown.com/sign-in).
 2. Click on your Project.
 3. Click the Analytics Tab.
 4. Select the Analytics section of your choice.

--- a/cloud/chains/overview.mdx
+++ b/cloud/chains/overview.mdx
@@ -16,7 +16,7 @@ The WalletConnect protocol is multi-chain by design. By using the [CAIP-25 stand
 </Note>
 
 If you don't see your chain listed in this [list](./chain-list), then you will need to create an issue in GitHub to to get the process started.
-You can do so by clicking [here](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=). Once your chain is added to this list, wallets & dapps will be able to indicate support for your chain via WalletConnect's [Cloud](https://cloud.reown.com).
+You can do so by clicking [here](https://github.com/WalletConnect/walletconnect-monorepo/issues/new?assignees=&labels=type%3A+new+chain+request&template=new_chain_to_explorer.md&title=). Once your chain is added to this list, wallets & dapps will be able to indicate support for your chain via Reown [Cloud Dashboard](https://dashboard.reown.com).
 
 ## CASA
 

--- a/cloud/explorer-submission.mdx
+++ b/cloud/explorer-submission.mdx
@@ -11,7 +11,7 @@ However, doing so ensures that your project is listed under [WalletGuide](https:
 
 ## Creating a New Project
 
-- Head over to [cloud.reown.com](https://cloud.reown.com/) and create a new project by clicking the "New Project" button in top right corner of the dashboard.
+- Head over to [dashboard.reown.com](https://dashboard.reown.com/) and create a new project by clicking the "New Project" button in top right corner of the dashboard.
 - Give a suitable name to your project, select whether its an App or Wallet and click the "Create" button. (You can change this later)
 
   <Frame>

--- a/cloud/explorer.mdx
+++ b/cloud/explorer.mdx
@@ -13,7 +13,7 @@ By default listings endpoints return all data for provided type. You can use fol
 
 | Param       | Required? | Description                                                                                                              |
 | ----------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
-| projectId   | Required  | Your Reown Cloud Project ID (from [cloud.reown.com](https://cloud.reown.com/))                   |
+| projectId   | Required  | Your Reown Cloud Project ID (from [dashboard.reown.com](https://dashboard.reown.com/))                   |
 | entries     |           | Specifies how many entries will be returned (must be used together with page param)                                      |
 | page        |           | Specifies current page (must be used with entries param)                                                                 |
 | search      |           | Returns listings whose name matches provided search query                                                                |
@@ -102,7 +102,7 @@ Examples:
 
 | Param     | Required? | Description                                                                                            |
 | --------- | --------- | ------------------------------------------------------------------------------------------------------ |
-| projectId | Required  | Your Reown Cloud Project ID (from [cloud.reown.com](https://cloud.reown.com/)) |
+| projectId | Required  | Your Reown Cloud Project ID (from [dashboard.reown.com](https://dashboard.reown.com/)) |
 
 #### `GET /v3/logo/:size/:image_id`
 

--- a/cloud/paymaster.mdx
+++ b/cloud/paymaster.mdx
@@ -9,7 +9,7 @@ title: Paymaster
 
 ## Accessing Reown Paymaster
 
-1. Log in to your Cloud Account [here](https://cloud.reown.com/sign-in).
+1. Log in to your Cloud Account [here](https://dashboard.reown.com/sign-in).
 2. Click on your Project, then select the "Paymaster" Tab.
 
 ## Creating a Policy

--- a/cloud/relay.mdx
+++ b/cloud/relay.mdx
@@ -8,7 +8,7 @@ The Project ID is consumed through URL parameters.
 
 URL parameters used:
 
-- `projectId`: Your Project ID can be obtained from [cloud.reown.com](https://cloud.reown.com)
+- `projectId`: Your Project ID can be obtained from [dashboard.reown.com](https://dashboard.reown.com)
 
 Example URL:
 

--- a/cloud/verify.mdx
+++ b/cloud/verify.mdx
@@ -10,7 +10,7 @@ Once a wallet knows whether an end-user is on uniswap.com or eviluniswap.com, it
 
 In order to verify your app domain in Reown Cloud follow these steps:
 
-1. Head over to [Reown Cloud](https://cloud.reown.com)
+1. Head over to [Reown Cloud Dashboard](https://dashboard.reown.com)
 
 2. Create a new project or click on the project you would like to verify.
 

--- a/docs.json
+++ b/docs.json
@@ -1229,7 +1229,7 @@
     "links": [
       {
         "label": "Cloud Dashboard",
-        "href": "https://cloud.reown.com/?utm_source=navbar&utm_medium=docs&utm_campaign=backlinks&_gl=1*9m24on*_ga*ODM2NjA0NjY2LjE3NDI0MzkzNzM.*_ga_X117BZWK4X*MTc0MjQzOTM3My4xLjEuMTc0MjQzOTkzNi4wLjAuMA.."
+        "href": "https://dashboard.reown.com/?utm_source=navbar&utm_medium=docs&utm_campaign=backlinks&_gl=1*9m24on*_ga*ODM2NjA0NjY2LjE3NDI0MzkzNzM.*_ga_X117BZWK4X*MTc0MjQzOTM3My4xLjEuMTc0MjQzOTkzNi4wLjAuMA.."
       }
     ],
     "primary": {

--- a/snippets/appkit/javascript/bitcoin/about/implementation.mdx
+++ b/snippets/appkit/javascript/bitcoin/about/implementation.mdx
@@ -10,7 +10,7 @@ import { createAppKit } from '@reown/appkit'
 import { BitcoinAdapter } from '@reown/appkit-adapter-bitcoin'
 import { bitcoin } from '@reown/appkit/networks'
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks

--- a/snippets/appkit/javascript/ethers/about/implementation.mdx
+++ b/snippets/appkit/javascript/ethers/about/implementation.mdx
@@ -5,7 +5,7 @@ import { createAppKit } from "@reown/appkit";
 import { EthersAdapter } from "@reown/appkit-adapter-ethers";
 import { mainnet, arbitrum } from "@reown/appkit/networks";
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create your application's metadata object

--- a/snippets/appkit/javascript/ethers5/implementation.mdx
+++ b/snippets/appkit/javascript/ethers5/implementation.mdx
@@ -5,7 +5,7 @@ import { createAppKit } from "@reown/appkit";
 import { Ethers5Adapter } from "@reown/appkit-adapter-ethers5";
 import { mainnet, arbitrum } from "@reown/appkit/networks";
 
-// 1. Get projectId at https://cloud.reown.com
+// 1. Get projectId at https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create your application's metadata object

--- a/snippets/appkit/javascript/solana/about/implementation.mdx
+++ b/snippets/appkit/javascript/solana/about/implementation.mdx
@@ -10,7 +10,7 @@ import { solana, solanaTestnet, solanaDevnet } from "@reown/appkit/networks";
 // 0. Set up Solana Adapter
 const solanaWeb3JsAdapter = new SolanaAdapter();
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create a metadata object - optional

--- a/snippets/appkit/javascript/wagmi/about/implementation.mdx
+++ b/snippets/appkit/javascript/wagmi/about/implementation.mdx
@@ -9,7 +9,7 @@ import { createAppKit } from '@reown/appkit'
 import { mainnet, arbitrum } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 
-// 1. Get a project ID at https://cloud.reown.com
+// 1. Get a project ID at https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 export const networks = [mainnet, arbitrum]

--- a/snippets/appkit/next/bitcoin/about/implementation.mdx
+++ b/snippets/appkit/next/bitcoin/about/implementation.mdx
@@ -10,7 +10,7 @@ import { createAppKit } from '@reown/appkit/react'
 import { BitcoinAdapter } from '@reown/appkit-adapter-bitcoin'
 import { bitcoin  } from '@reown/appkit/networks'
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks

--- a/snippets/appkit/next/ethers/about/implementation.mdx
+++ b/snippets/appkit/next/ethers/about/implementation.mdx
@@ -7,7 +7,7 @@ import { createAppKit } from "@reown/appkit/react";
 import { EthersAdapter } from "@reown/appkit-adapter-ethers";
 import { mainnet, arbitrum } from "@reown/appkit/networks";
 
-// 1. Get projectId at https://cloud.reown.com
+// 1. Get projectId at https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create a metadata object

--- a/snippets/appkit/next/ethers5/implementation.mdx
+++ b/snippets/appkit/next/ethers5/implementation.mdx
@@ -7,7 +7,7 @@ import { createAppKit } from "@reown/appkit/react";
 import { Ethers5Adapter } from "@reown/appkit-adapter-ethers5";
 import { mainnet, arbitrum } from "@reown/appkit/networks";
 
-// 1. Get projectId at https://cloud.reown.com
+// 1. Get projectId at https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create a metadata object

--- a/snippets/appkit/next/solana/about/implementation.mdx
+++ b/snippets/appkit/next/solana/about/implementation.mdx
@@ -11,7 +11,7 @@ import { solana, solanaTestnet, solanaDevnet } from "@reown/appkit/networks";
 // 0. Set up Solana Adapter
 const solanaWeb3JsAdapter = new SolanaAdapter();
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create a metadata object - optional

--- a/snippets/appkit/next/wagmi/about/implementation.mdx
+++ b/snippets/appkit/next/wagmi/about/implementation.mdx
@@ -13,7 +13,7 @@ import { cookieStorage, createStorage, http } from '@wagmi/core'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { mainnet, arbitrum } from '@reown/appkit/networks'
 
-// Get projectId from https://cloud.reown.com
+// Get projectId from https://dashboard.reown.com
 export const projectId = process.env.NEXT_PUBLIC_PROJECT_ID
 
 if (!projectId) {

--- a/snippets/appkit/nuxt/wagmi/about/implementation.mdx
+++ b/snippets/appkit/nuxt/wagmi/about/implementation.mdx
@@ -92,7 +92,7 @@ createAppKit({
 ```
 
 <Note>
-  Make sure to set your `NUXT_PROJECT_ID` environment variable which you can get from [Reown Cloud](https://cloud.reown.com).
+  Make sure to set your `NUXT_PROJECT_ID` environment variable which you can get from [Reown Cloud Dashboard](https://dashboard.reown.com).
 </Note>
 
 <Note>

--- a/snippets/appkit/react-native/ethers/about/implementation.mdx
+++ b/snippets/appkit/react-native/ethers/about/implementation.mdx
@@ -20,7 +20,7 @@ import {
   AppKit,
 } from "@reown/appkit-ethers-react-native";
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create config

--- a/snippets/appkit/react-native/ethers5/about/implementation.mdx
+++ b/snippets/appkit/react-native/ethers5/about/implementation.mdx
@@ -21,7 +21,7 @@ import {
   AppKit,
 } from "@reown/appkit-ethers5-react-native";
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create config

--- a/snippets/appkit/react-native/wagmi/about/implementation.mdx
+++ b/snippets/appkit/react-native/wagmi/about/implementation.mdx
@@ -25,7 +25,7 @@ import {
 // 0. Setup queryClient
 const queryClient = new QueryClient();
 
-// 1. Get projectId at https://cloud.reown.com
+// 1. Get projectId at https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create config

--- a/snippets/appkit/react/bitcoin/about/implementation.mdx
+++ b/snippets/appkit/react/bitcoin/about/implementation.mdx
@@ -10,7 +10,7 @@ import { createAppKit } from '@reown/appkit/react'
 import { BitcoinAdapter } from '@reown/appkit-adapter-bitcoin'
 import { bitcoin } from '@reown/appkit/networks'
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks

--- a/snippets/appkit/react/core/about/implementation.mdx
+++ b/snippets/appkit/react/core/about/implementation.mdx
@@ -13,7 +13,7 @@ import type { InferredCaipNetwork } from '@reown/appkit-common'
 import UniversalProvider from '@walletconnect/universal-provider'
 import { AppKit, createAppKit } from '@reown/appkit/core'
 
-// Get projectId from https://cloud.reown.com
+// Get projectId from https://dashboard.reown.com
 export const projectId = import.meta.env.VITE_PROJECT_ID || "b56e18d47c72ab683b10814fe9495694" // this is a public projectId only to use on localhost
 
 if (!projectId) {

--- a/snippets/appkit/react/solana/about/implementation.mdx
+++ b/snippets/appkit/react/solana/about/implementation.mdx
@@ -11,7 +11,7 @@ import { solana, solanaTestnet, solanaDevnet } from "@reown/appkit/networks";
 // 0. Set up Solana Adapter
 const solanaWeb3JsAdapter = new SolanaAdapter();
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = "YOUR_PROJECT_ID";
 
 // 2. Create a metadata object - optional

--- a/snippets/appkit/react/wagmi/about/implementation.mdx
+++ b/snippets/appkit/react/wagmi/about/implementation.mdx
@@ -15,7 +15,7 @@ import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 // 0. Setup queryClient
 const queryClient = new QueryClient()
 
-// 1. Get projectId from https://cloud.reown.com
+// 1. Get projectId from https://dashboard.reown.com
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Create a metadata object - optional

--- a/snippets/cloud-banner.mdx
+++ b/snippets/cloud-banner.mdx
@@ -2,11 +2,11 @@
 
 **Don't have a project ID?**
 
-Head over to Reown Cloud and create a new project now!
+Head over to Reown Cloud Dashboard and create a new project now!
 
 <Card
   title="Get started"
-  href="https://cloud.reown.com/?utm_source=cloud_banner&utm_medium=docs&utm_campaign=backlinks"
+  href="https://dashboard.reown.com/?utm_source=cloud_banner&utm_medium=docs&utm_campaign=backlinks"
 />
 
 </Info>


### PR DESCRIPTION
## Description

This PR updates the old Cloud links to point to the new Cloud Dashboard link. 

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- [Preview Link 1](https://docs.reown.com)
