### PR TITLE
Docs Upadte: Removing Notify from API section of the docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -174,10 +174,6 @@
                     "pages": ["advanced/api/core/pairing", "advanced/api/core/relay", "advanced/api/core/shared-core"]
                   },
                   {
-                    "group": "Notify",
-                    "pages": ["advanced/api/notify/about"]
-                  },
-                  {
                     "group": "Sign",
                     "pages": [
                       "advanced/api/sign/overview",


### PR DESCRIPTION
## Description

This PR removes the Notify doc page from the API section of the docs. 

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- [Preview Link 1]()
- [Preview Link 2]()
