### PR TITLE
feat: add btc, sui and stacks accounts caching to RPC specs

### DIFF
--- a/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
+++ b/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
@@ -32,6 +32,14 @@ If the wallet user changes to account 1 we get path `m/84'/0'/1'/0/0` with ident
 - `m/84'/0'/1'/change/address_index`
 - `m/86'/0'/1'/change/address_index`
 
+
+## Connection
+### Session Properties
+
+In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.bip122_getAccountAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys and paths from the wallet.
+
+## RPC Methods
+
 ## sendTransfer
 
 This method is used to sign and submit a transfer of any `amount` of Bitcoin to a single `recipientAddress`, optionally including a `changeAddress` for the change amount and `memo` set as an OP_RETURN output by supporting wallets. The transaction will be signed and broadcast upon user approval.

--- a/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
+++ b/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
@@ -33,13 +33,6 @@ If the wallet user changes to account 1 we get path `m/84'/0'/1'/0/0` with ident
 - `m/86'/0'/1'/change/address_index`
 
 
-## Connection
-### Session Properties
-
-In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.bip122_getAccountAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys and paths from the wallet.
-
-## RPC Methods
-
 ## sendTransfer
 
 This method is used to sign and submit a transfer of any `amount` of Bitcoin to a single `recipientAddress`, optionally including a `changeAddress` for the change amount and `memo` set as an OP_RETURN output by supporting wallets. The transaction will be signed and broadcast upon user approval.
@@ -118,6 +111,10 @@ We recognize that there are two broad classes of wallets in use today:
     - `publicKey` : `String` - _(Optional)_ Public key for the derivation path in hex, without 0x prefix.
     - `path` : `String` - _(Optional)_ Derivation path of the address e.g. "m/84'/0'/0'/0/0".
     - `intention` : `String` - _(Optional)_ Intention of the address, e.g. "payment" or "ordinal".
+
+### Session Properties
+In a connection request, it is recommended to serialize the response to `getAccountAddresses` in `session.sessionProperties.bip122_getAccountAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
+
 
 ### Example: Dynamic Wallet
 

--- a/advanced/multichain/rpc-reference/stacks-rpc.mdx
+++ b/advanced/multichain/rpc-reference/stacks-rpc.mdx
@@ -3,8 +3,16 @@ title: "Stacks"
 description: Stacks JSON-RPC Methods
 ---
 
-These are the methods that wallets should implement to handle Stacks transfers and messages via WalletConnect.
 
+## Conection
+
+### Session Properties
+
+In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.stacks_getAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
+
+## RPC Methods
+
+These are the methods that wallets should implement to handle Stacks transfers and messages via WalletConnect.
 
 ## stx_transferStx
 

--- a/advanced/multichain/rpc-reference/stacks-rpc.mdx
+++ b/advanced/multichain/rpc-reference/stacks-rpc.mdx
@@ -4,14 +4,6 @@ description: Stacks JSON-RPC Methods
 ---
 
 
-## Conection
-
-### Session Properties
-
-In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.stacks_getAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
-
-## RPC Methods
-
 These are the methods that wallets should implement to handle Stacks transfers and messages via WalletConnect.
 
 ## stx_transferStx
@@ -97,3 +89,42 @@ For signing a message with wallet users private key.
 ```
 
 - `signature` - The signature of the message
+
+
+
+
+## stx_getAddresses
+
+For requesting the wallet addresses
+
+### Request
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "stx_getAddresses",
+}
+```
+
+### Response
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "accounts": [
+      { 
+        "address": "SP23....",
+        "publicKey": "ab12031..."
+      }
+    ]
+  }
+}
+```
+
+- `accounts`: The connected accounts with their address and publicKey
+
+
+### Session Properties
+In a connection request, it is recommended to serialize the response to `getAddresses` in `session.sessionProperties.stacks_getAddresses`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.

--- a/advanced/multichain/rpc-reference/sui-rpc.mdx
+++ b/advanced/multichain/rpc-reference/sui-rpc.mdx
@@ -3,20 +3,11 @@ title: "Sui"
 description: Sui JSON-RPC Methods
 ---
 
+These are the methods that wallets should implement to handle Sui transactions and messages via WalletConnect.
 
 <Note type="warning">
 **Please note:** The SUI RPC standard is still under review and specifications may change. Implementation details and method signatures are subject to updates.
 </Note>
-
-## Conection
-
-### Session Properties
-
-In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.sui_getAccounts`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
-
-## RPC Methods
-
-These are the methods that wallets should implement to handle Sui transactions and messages via WalletConnect.
 
 ## sui_getAccounts
 
@@ -53,7 +44,12 @@ This method returns an Array of public keys and addresses available to sign from
 }
 ```
 
-### sui_signTransaction
+### Session Properties
+In a connection request, it is recommended to serialize the response to `getAccounts` in `session.sessionProperties.sui_getAccounts`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
+
+
+
+## sui_signTransaction
 
 Sign a Sui transaction without executing it.
 

--- a/advanced/multichain/rpc-reference/sui-rpc.mdx
+++ b/advanced/multichain/rpc-reference/sui-rpc.mdx
@@ -3,11 +3,20 @@ title: "Sui"
 description: Sui JSON-RPC Methods
 ---
 
-These are the methods that wallets should implement to handle Sui transactions and messages via WalletConnect.
 
 <Note type="warning">
 **Please note:** The SUI RPC standard is still under review and specifications may change. Implementation details and method signatures are subject to updates.
 </Note>
+
+## Conection
+
+### Session Properties
+
+In a connection request, all wallets **should** serialize the connected accounts in `session.sessionProperties.sui_getAccounts`. This allows dapps to consume an active session without requiring a context switch to re-request all addresses and associated public keys from the wallet.
+
+## RPC Methods
+
+These are the methods that wallets should implement to handle Sui transactions and messages via WalletConnect.
 
 ## sui_getAccounts
 


### PR DESCRIPTION
## Description

- Adds recommendation to serialize responses to `sui_getAccounts`, `stacks_getAddresses` and `bip122_getAccountAddresses` in `sessionProperties` 

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- [Preview Link 1]()
- [Preview Link 2]()
