### PR TITLE
Add hedera network to supported networks list

### DIFF
--- a/reown-appkit.mdc
+++ b/reown-appkit.mdc
@@ -96,7 +96,7 @@ export const config = wagmiAdapter.wagmiConfig
 All supported **Viem networks** are available via `@reown/appkit/networks`:
 
 ```ts
-import { mainnet, arbitrum, base, scroll, polygon } from '@reown/appkit/networks'
+import { mainnet, arbitrum, base, scroll, polygon, hedera } from '@reown/appkit/networks'
 ```
 
 ---


### PR DESCRIPTION
## Description

Add hedera network to supported networks list in cursor mdc file to reduce hallucinations and affirm to AI Agent that Hedera is supported.

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.
