### PR TITLE
Docs Update: Updating `Android` to `Kotlin` and `iOS` to `Swift` in the sidebar

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -730,9 +730,9 @@
             ]
           },
           {
-            "dropdown": "Android",
+            "dropdown": "Kotlin",
             "icon": "android",
-            "description": "AppKit on Android",
+            "description": "AppKit on Kotlin (Android)",
             "pages": [
               {
                 "group": "Fundamentals",
@@ -762,9 +762,9 @@
             ]
           },
           {
-            "dropdown": "iOS",
+            "dropdown": "Swift",
             "icon": "apple",
-            "description": "AppKit on iOS",
+            "description": "AppKit on Swift (iOS)",
             "pages": [
               {
                 "group": "Fundamentals",


### PR DESCRIPTION
## Description

This PR updates the AppKit sidebar to rename "Android" to Kotlin and "iOS" to "Swift". 

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- [Preview Link 1](https://reown-5552f0bb-sidebar-rename.mintlify.app/appkit/overview)
