### PR TITLE
Feat: add the only port available in AppKit Pay Localhost

### DIFF
--- a/snippets/appkit/shared/appkit-pay-react.mdx
+++ b/snippets/appkit/shared/appkit-pay-react.mdx
@@ -94,6 +94,17 @@ const paymentAssetDetails = {
 };
 ```
 
+## Test locally
+
+In order to test locally use localhost and port 3000. This is the only port available for local testing.
+
+Add the following to your package.json file:
+```json
+"scripts": {
+    "dev": "vite --port 3000",
+},
+```
+
 ## Test the complete exchange flow
 
 To test the entire exchange process, we've implemented a dedicated test scenario that activates when using the token `baseSepoliaETH`.


### PR DESCRIPTION
## Description

 add the only port available in AppKit Pay Localhost

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

https://reown-5552f0bb-feat-add-port-testing-pay.mintlify.app/appkit/react/payments/pay-with-exchange#test-locally
