### PR TITLE
Docs Update: Addressing team's feedback on AppKit Bitcoin

### DIFF
--- a/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
+++ b/advanced/multichain/rpc-reference/bitcoin-rpc.mdx
@@ -181,6 +181,10 @@ Assuming the dapp monitors all returned addresses for balance changes, a new req
 
 The example below specifies a response from a static wallet. The returned address is used for both change and payments. It's the only address with UTXOs.
 
+<Note>
+  Hardware wallets utilizing `bip32` are also supported. 
+</Note>
+
 ```javascript
 // Request
 {

--- a/appkit/networks/bitcoin.mdx
+++ b/appkit/networks/bitcoin.mdx
@@ -23,6 +23,14 @@ Currently, the following extension wallets are supported:
 - **Leather**
 - **Phantom**.
 
+Here is the list of supported Bitcoin JSON-RPC methods:
+1. `sendTransfer`
+2. `getAccountAddresses`
+3. `signPSBT`
+4. `signMessage`
+
+You can find more information about the supported Bitcoin RPC methods [here](/advanced/multichain/rpc-reference/bitcoin-rpc).
+
 While we provide a standardized interface for Bitcoin connector methods, not all wallets support every method. As a result, you may encounter a `MethodNotSupportedError` when attempting to use methods that are not supported by a specific wallet.
 If your wallet supports a mentioned standard but you cannot connect, please reach out to our development team for assistance via [Github issues](https://github.com/reown-com/appkit/issues/new/choose).
 <Card title="Try Demo" href="https://appkit-lab.reown.com/appkit/?name=bitcoin" horizontal />


### PR DESCRIPTION
## Description

This PR highlights the Bitcoin JSON-RPC methods supported by AppKit and also adds a note that we support `bip32` hardware wallets. 

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- [Preview Link 1]()
- [Preview Link 2]()
