### PR TITLE
Docs Update: Removing AppKit subscription doc page

### DIFF
--- a/appkit/payments/overview.mdx
+++ b/appkit/payments/overview.mdx
@@ -69,12 +69,5 @@ With **multi-platform SDKs**, **battle-tested infrastructure**, and **exclusive 
   >
     Get started with AppKit Pay One-Click Checkout.
   </Card>
-
-  <Card
-    title="Subscriptions & Recurring Payments"
-    icon="repeat"
-    href="/appkit/payments/subscriptions"
-  >
-    Get started with AppKit Pay Subscriptions & Recurring Payments.
-  </Card>
+  
 </CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -267,8 +267,7 @@
                       "appkit/payments/overview",
                       "appkit/payments/pay-with-exchange",
                       "appkit/payments/deposit-with-exchange",
-                      "appkit/payments/one-click-checkout",
-                      "appkit/payments/subscriptions"
+                      "appkit/payments/one-click-checkout"
                     ]
                   },
                   {


### PR DESCRIPTION
## Description

This PR temporarily removes the Subscription page from AppKit Payments section of the docs. 

## Tests

- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct link to the deployed preview files

- 
