### PR TITLE
Fix malformed code blocks and formatting in Sign SDK overview documen…

### DIFF
--- a/advanced/api/sign/overview.mdx
+++ b/advanced/api/sign/overview.mdx
@@ -15,9 +15,18 @@ WalletConnect Sign is a remote signer protocol to communicate securely between w
 <Tab title="Web">
 
 <CodeGroup>
-  ```bash npm npm install @walletconnect/sign-client ``` ```bash Yarn yarn add
-  @walletconnect/sign-client ``` ```bash Bun bun add @walletconnect/sign-client
-  ``` ```bash pnpm pnpm add @walletconnect/sign-client ```
+```bash npm
+npm install @walletconnect/sign-client
+```
+```bash yarn
+yarn add @walletconnect/sign-client
+```
+```bash bun
+bun add @walletconnect/sign-client
+```
+```bash pnpm
+pnpm add @walletconnect/sign-client
+```
 </CodeGroup>
 
 <Note>
@@ -27,22 +36,27 @@ For Node.js, the WalletConnect SignClient additionally requires `lokijs` to mana
 </Note>
 
 <CodeGroup>
-  ```bash npm npm install --save @walletconnect/sign-client lokijs@1.x ```
-  ```bash Yarn yarn add @walletconnect/sign-client lokijs@1.x ``` ```bash Bun
-  bun add --save @walletconnect/sign-client lokijs@1.x ``` ```bash pnpm pnpm add
-  @walletconnect/sign-client lokijs@1.x ```
+```bash npm
+npm install --save @walletconnect/sign-client lokijs@1.x
+```
+```bash yarn
+yarn add @walletconnect/sign-client lokijs@1.x
+```
+```bash bun
+bun add --save @walletconnect/sign-client lokijs@1.x
+```
+```bash pnpm
+pnpm add @walletconnect/sign-client lokijs@1.x
+```
 </CodeGroup>
 
 </Tab>
 
 <Tab title="iOS">
-  <Tabs
-queryString="ios-method"
-	values={[
-		{ label: 'SwiftPackageManager', value: 'spm', },
-		{ label: 'Cocoapods', value: 'cocoa', },
-	]}
->
+<Tabs queryString="ios-method" values={[
+  { label: 'SwiftPackageManager', value: 'spm', },
+  { label: 'Cocoapods', value: 'cocoa', },
+]}>
 <Tab title="SwiftPackageManager">
 
 You can add a WalletConnect SDK to your project with Swift Package Manager. In order to do that:
@@ -59,7 +73,6 @@ You can add a WalletConnect SDK to your project with Swift Package Manager. In o
 1. Update Cocoapods spec repos. Type in terminal `pod repo update`
 2. Initialize Podfile if needed with `pod init`
 3. Add pod to your Podfile:
-
 ```ruby
 pod 'WalletConnectSwiftV2'
 ```
@@ -67,7 +80,6 @@ pod 'WalletConnectSwiftV2'
 4. Install pods with `pod install`
 
 If you encounter any problems during package installation, you can specify the exact path to the repository
-
 ```ruby
 pod 'WalletConnectSwiftV2', :git => 'https://github.com/reown-com/reown-swift.git', :tag => '1.0.5'
 ```
@@ -90,18 +102,16 @@ Kotlin implementation of WalletConnect v2 Sign protocol for Android applications
 #### Installation
 
 root/build.gradle.kts:
-
 ```gradle
 allprojects {
- repositories {
+  repositories {
     mavenCentral()
     maven { url "https://jitpack.io" }
- }
+  }
 }
 ```
 
 app/build.gradle.kts
-
 ```gradle
 implementation("com.walletconnect:android-core:release_version")
 implementation("com.walletconnect:sign:release_version")
@@ -111,7 +121,6 @@ implementation("com.walletconnect:sign:release_version")
 
 <Tab title="Flutter">
 Install the WalletConnect client package.
-
 ```dart
 flutter pub add walletconnect_flutter_v2
 ```
@@ -123,7 +132,6 @@ Depending on your platform, you will have to add different permissions to get th
 #### MacOS
 
 Add the following to your `DebugProfile.entitlements` and `Release.entitlements` files so that it can connect to the WebSocket server.
-
 ```xml
 <key>com.apple.security.network.client</key>
 <true/>
@@ -136,7 +144,6 @@ Add the following to your `DebugProfile.entitlements` and `Release.entitlements`
 #### Install via Packages
 
 Install the WalletConnect Sign Client package via Nuget.
-
 ```shell
 dotnet add package WalletConnect.Sign
 ```
@@ -159,7 +166,6 @@ WalletConnectUnity.Core is a Unity package that provides a client implementation
 <Tab title="OpenUPM CLI">
 
 To install packages via OpenUPM, you need to have [Node.js](https://nodejs.org/en/) and [openupm-cli](https://openupm.com/docs/getting-started.html#installing-openupm-cli) installed. Once you have them installed, you can run the following commands:
-
 ```bash
 openupm add com.walletconnect.core
 ```
@@ -168,7 +174,7 @@ openupm add com.walletconnect.core
 
 <Tab title="Package Manager with OpenUPM">
 
-1. Open `Advanced Project Settings` from the gear ⚙ menu located at the top right of the Package Manager’s toolbar
+1. Open `Advanced Project Settings` from the gear ⚙ menu located at the top right of the Package Manager's toolbar
 2. Add a new scoped registry with the following details:
    - Name: `OpenUPM`
    - URL: `https://package.openupm.com`
@@ -184,12 +190,11 @@ openupm add com.walletconnect.core
 
 <Tab title="Package Manager with Git URL">
 
-1. Open the add ➕ menu in the Package Manager’s toolbar
+1. Open the add ➕ menu in the Package Manager's toolbar
 2. Select `Add package from git URL...`
 3. Enter the package URL:
 
 **WalletConnectUnity Core**
-
 ```
 https://github.com/WalletConnect/WalletConnectUnity.git?path=Packages/com.walletconnect.core
 ```
@@ -198,7 +203,6 @@ https://github.com/WalletConnect/WalletConnectUnity.git?path=Packages/com.wallet
 
 It's possible to lock the version of the package by adding `#{version}` at the end of the git URL, where `#{version}` is the git tag of the version you want to use.
 For example, to install version `1.0.1` of WalletConnectUnity Modal, use the following URL:
-
 ```
 https://github.com/WalletConnect/WalletConnectUnity.git?path=Packages/com.walletconnect.core#core/1.0.1
 ```
@@ -213,7 +217,6 @@ Due to WebGL's single-threaded nature, certain asynchronous operations like `Tas
 To enable these operations in WebGL builds, an additional third-party package, [WebGLThreadingPatcher](https://github.com/VolodymyrBS/WebGLThreadingPatcher), is required. This package modifies the Unity WebGL build to delegate work to the `SynchronizationContext`, allowing these operations to be executed on the same thread without blocking the main application. Please note that all tasks are still executed on a single thread, and any blocking calls will freeze the entire application.
 
 The [WebGLThreadingPatcher](https://github.com/VolodymyrBS/WebGLThreadingPatcher) package can be added via git URL:
-
 ```
 https://github.com/VolodymyrBS/WebGLThreadingPatcher.git
 ```


### PR DESCRIPTION
Fixed critical formatting issues in the Sign SDK overview documentation (`overview.mdx`) that made installation instructions difficult to read and copy:

**Main Issues Fixed:**
1. **Malformed CodeGroup blocks**: Restructured collapsed package manager installation commands in the Web tab that were improperly formatted on single lines, making them unreadable and unusable
2. **Node.js installation section**: Fixed the same formatting issue in the lokijs installation CodeGroup
3. **Improved code formatting**: Cleaned up indentation and spacing throughout all platform-specific installation sections for better readability

**Impact:**
- Users can now properly copy and paste installation commands for npm, yarn, bun, and pnpm
- Installation instructions are now clear and accessible across all supported platforms
- Improved overall documentation quality and user experience

## Tests
- [x] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [x] - Ran a grammar check on the updated/created content using ChatGPT.
- [x] - Verified all code blocks render correctly with proper syntax highlighting
- [x] - Confirmed installation commands are properly separated and copyable

## Direct link to the deployed preview files
- [Preview Link](https://docs.reown.com/advanced/api/sign/overview)