### PR TITLE
docs: add logger option to AppKit React Native createAppKit reference

### DIFF
--- a/appkit/react-native/core/options.mdx
+++ b/appkit/react-native/core/options.mdx
@@ -518,6 +518,17 @@ createAppKit({
 })
 ```
 
+### `logger`
+*   **Type:** `'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'` (Optional)
+*   **Description:** Controls the log level forwarded to `@walletconnect/universal-provider`. Useful for silencing or tuning WalletConnect core logs. When omitted, WalletConnect's default logging is preserved.
+
+```typescript
+createAppKit({
+  //...
+  logger: 'silent'
+})
+```
+
 ### universalProviderConfigOverride
 
 Lets you customize specific aspects of the provider's behavior.

--- a/appkit/react-native/core/options.mdx
+++ b/appkit/react-native/core/options.mdx
@@ -520,7 +520,8 @@ createAppKit({
 
 ### `logger`
 *   **Type:** `'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'` (Optional)
-*   **Description:** Controls the log level forwarded to `@walletconnect/universal-provider`. Useful for silencing or tuning WalletConnect core logs. When omitted, WalletConnect's default logging is preserved.
+*   **Default:** `'error'`
+*   **Description:** Controls the log level forwarded to `@walletconnect/universal-provider`. Useful for silencing or tuning WalletConnect core logs.
 
 ```typescript
 createAppKit({


### PR DESCRIPTION
## Description

Documents the new optional `logger` config option added to `createAppKit` in [appkit-react-native#558](https://github.com/reown-com/appkit-react-native/pull/558). The new section is placed in `appkit/react-native/core/options.mdx` under "Utility & Advanced Options" (next to `debug`) and lists the accepted log levels (`'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'`), noting that omitting it preserves WalletConnect's default logging.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.