### PR TITLE
docs: add TRON support to Next.js AppKit installation

### DIFF
--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -187,19 +187,19 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+npm install @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+yarn add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+bun add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+pnpm add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 </CodeGroup>

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -187,19 +187,19 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-tron
+npm install @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-tron
+yarn add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-tron
+bun add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-tron
+pnpm add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 </CodeGroup>
@@ -287,7 +287,9 @@ Check the Next TON example
 
 </Tab>
 <Tab title="TRON">
-
+<Card title="TRON Example" icon="github" href="https://github.com/reown-com/appkit-web-examples/tree/main/nextjs/next-tron-app-router">
+Check the Next TRON example
+</Card>
 <TronImplementation />
 
 </Tab>

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -17,10 +17,12 @@ import BitcoinImplementation from '/snippets/appkit/next/bitcoin/about/implement
 
 import TonImplementation from '/snippets/appkit/next/ton/about/implementation.mdx'
 
+import TronImplementation from '/snippets/appkit/next/tron/about/implementation.mdx'
+
 import CoreImplementation from '/snippets/appkit/react/core/about/implementation.mdx'
 
 AppKit provides seamless integration with multiple blockchain ecosystems. It supports [Wagmi](https://wagmi.sh/) and [Ethers v6](https://docs.ethers.org/v6/) on Ethereum,
-[@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana, as well as Bitcoin, TON and other networks.
+[@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana, as well as Bitcoin, TON, TRON and other networks.
 
 <Note>
   These steps are specific to [Next.js](https://nextjs.org/) app router. For other React frameworks
@@ -180,6 +182,29 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 </CodeGroup>
 
 </Tab>
+<Tab title="TRON">
+
+<CodeGroup>
+
+```bash npm
+npm install @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash Yarn
+yarn add @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash Bun
+bun add @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash pnpm
+pnpm add @reown/appkit @reown/appkit-adapter-tron
+```
+
+</CodeGroup>
+
+</Tab>
 <Tab title="Others networks (AppKit Core)">
 
 <CodeGroup>
@@ -259,6 +284,11 @@ Check the Next Bitcoin example
 Check the Next TON example
 </Card>
 <TonImplementation />
+
+</Tab>
+<Tab title="TRON">
+
+<TronImplementation />
 
 </Tab>
 <Tab title="Others networks (AppKit Core)">

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -189,19 +189,19 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-tron
+npm install @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-tron
+yarn add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-tron
+bun add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-tron
+pnpm add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
 ```
 
 </CodeGroup>

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -189,19 +189,19 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+npm install @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+yarn add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+bun add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-tron @tronweb3/tronwallet-adapter-tronlink
+pnpm add @reown/appkit @reown/appkit-adapter-tron
 ```
 
 </CodeGroup>

--- a/snippets/appkit/javascript/tron/about/implementation.mdx
+++ b/snippets/appkit/javascript/tron/about/implementation.mdx
@@ -6,7 +6,7 @@ On top of your app set up the following configuration.
 // App.tsx
 import { createAppKit } from '@reown/appkit'
 import { TronAdapter } from '@reown/appkit-adapter-tron'
-import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
+import { tronMainnet } from '@reown/appkit/networks'
 
 // Import wallet adapters you want to support
 import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
@@ -15,7 +15,7 @@ import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks
-const networks = [tronMainnet, tronShastaTestnet]
+const networks = [tronMainnet]
 
 // 3. Set up TRON Adapter with wallet adapters
 const tronAdapter = new TronAdapter({

--- a/snippets/appkit/next/tron/about/implementation.mdx
+++ b/snippets/appkit/next/tron/about/implementation.mdx
@@ -1,0 +1,221 @@
+AppKit TRON provides a set of React components and hooks to easily connect TRON wallets with your application.
+
+On top of your app set up the following configuration, making sure that all functions are called outside any React component to avoid unwanted rerenders.
+
+```tsx
+// App.tsx
+import { createAppKit } from '@reown/appkit/react'
+import { TronAdapter } from '@reown/appkit-adapter-tron'
+import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
+
+// Import wallet adapters you want to support
+import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
+
+// 1. Get projectId from https://dashboard.reown.com
+const projectId = 'YOUR_PROJECT_ID'
+
+// 2. Set the networks
+const networks = [tronMainnet, tronShastaTestnet]
+
+// 3. Set up TRON Adapter with wallet adapters
+const tronAdapter = new TronAdapter({
+  walletAdapters: [
+    new TronLinkAdapter({
+      openUrlWhenWalletNotFound: false,
+      checkTimeout: 3000
+    })
+  ]
+})
+
+// 4. Create a metadata object - optional
+const metadata = {
+  name: 'AppKit',
+  description: 'AppKit TRON Example',
+  url: 'https://example.com', // origin must match your domain & subdomain
+  icons: ['https://avatars.githubusercontent.com/u/179229932']
+}
+
+// 5. Create modal
+createAppKit({
+  adapters: [tronAdapter],
+  networks,
+  metadata,
+  projectId,
+  features: {
+    analytics: true, // Optional - defaults to your Dashboard configuration
+    email: false,
+    socials: []
+  }
+})
+
+export default function App() {
+  return <YourApp />
+}
+```
+
+## Install Wallet Adapters
+
+TRON adapter requires you to install wallet adapters separately. This gives you control over which wallets to support and reduces bundle size.
+
+<Tabs>
+<Tab title="TronLink">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-tronlink
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="MetaMask">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="Trust Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-trust
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-trust
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-trust
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-trust
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="OKX Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="BitKeep">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="Binance Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-binance
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-binance
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-binance
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-binance
+```
+
+</CodeGroup>
+</Tab>
+</Tabs>
+
+<Note>
+For a complete list of available TRON wallet adapters, visit the [official wallet adapter documentation](https://walletadapter.org/docs/guide/wallet-reference.html).
+</Note>
+
+### Using Multiple Wallet Adapters
+
+After installing your desired wallet adapters, import and add them to the `walletAdapters` array when creating the TRON adapter:
+
+```tsx
+import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
+import { MetaMaskAdapter } from '@tronweb3/tronwallet-adapter-metamask-tron'
+import { TrustAdapter } from '@tronweb3/tronwallet-adapter-trust'
+import { OkxWalletAdapter } from '@tronweb3/tronwallet-adapter-okxwallet'
+
+const tronAdapter = new TronAdapter({
+  walletAdapters: [
+    new TronLinkAdapter({
+      openUrlWhenWalletNotFound: false,
+      checkTimeout: 3000
+    }),
+    new MetaMaskAdapter(),
+    new TrustAdapter(),
+    new OkxWalletAdapter({
+      openUrlWhenWalletNotFound: false
+    })
+  ]
+})
+```

--- a/snippets/appkit/next/tron/about/implementation.mdx
+++ b/snippets/appkit/next/tron/about/implementation.mdx
@@ -6,7 +6,7 @@ On top of your app set up the following configuration, making sure that all func
 // App.tsx
 import { createAppKit } from '@reown/appkit/react'
 import { TronAdapter } from '@reown/appkit-adapter-tron'
-import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
+import { tronMainnet } from '@reown/appkit/networks'
 
 // Import wallet adapters you want to support
 import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
@@ -15,7 +15,7 @@ import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks
-const networks = [tronMainnet, tronShastaTestnet]
+const networks = [tronMainnet]
 
 // 3. Set up TRON Adapter with wallet adapters
 const tronAdapter = new TronAdapter({

--- a/snippets/appkit/react/tron/about/implementation.mdx
+++ b/snippets/appkit/react/tron/about/implementation.mdx
@@ -6,7 +6,7 @@ On top of your app set up the following configuration, making sure that all func
 // App.tsx
 import { createAppKit } from '@reown/appkit/react'
 import { TronAdapter } from '@reown/appkit-adapter-tron'
-import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
+import { tronMainnet } from '@reown/appkit/networks'
 
 // Import wallet adapters you want to support
 import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
@@ -15,7 +15,7 @@ import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks
-const networks = [tronMainnet, tronShastaTestnet]
+const networks = [tronMainnet]
 
 // 3. Set up TRON Adapter with wallet adapters
 const tronAdapter = new TronAdapter({

--- a/snippets/appkit/vue/tron/about/implementation.mdx
+++ b/snippets/appkit/vue/tron/about/implementation.mdx
@@ -9,7 +9,7 @@ In your `App.vue` file set up the following configuration.
 
 import { createAppKit } from '@reown/appkit/vue'
 import { TronAdapter } from '@reown/appkit-adapter-tron'
-import { tronMainnet, tronShastaTestnet } from '@reown/appkit/networks'
+import { tronMainnet } from '@reown/appkit/networks'
 
 // Import wallet adapters you want to support
 import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
@@ -18,7 +18,7 @@ import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
 const projectId = 'YOUR_PROJECT_ID'
 
 // 2. Set the networks
-const networks = [tronMainnet, tronShastaTestnet]
+const networks = [tronMainnet]
 
 // 3. Set up TRON Adapter with wallet adapters
 const tronAdapter = new TronAdapter({


### PR DESCRIPTION
## Summary
- Add TRON network documentation to Next.js installation guide
- Create new TRON implementation snippet for Next.js (`snippets/appkit/next/tron/about/implementation.mdx`)
- Add TRON tab to installation packages section
- Add TRON tab to implementation section
- Update intro paragraph to mention TRON support

This matches the existing React documentation structure for TRON integration at https://docs.reown.com/appkit/react/core/installation#tron

## Test plan
- [ ] Verify the Next.js installation page displays the TRON tab correctly
- [ ] Verify the TRON implementation snippet renders properly
- [ ] Confirm code examples are accurate and match React TRON documentation

Slack thread: https://reown-inc.slack.com/archives/C03US3FRU9L/p1779646479442669

https://claude.ai/code/session_01KGKncdQybc5Wipq37L8Z91

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGKncdQybc5Wipq37L8Z91)_