### PR TITLE
docs: add TRON support to Svelte AppKit installation

### DIFF
--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -19,9 +19,12 @@ import SvelteBitcoinModal from '/snippets/appkit/svelte/bitcoin/about/triggermod
 import SvelteTonImplementation from '/snippets/appkit/svelte/ton/about/implementation.mdx'
 import SvelteTonModal from '/snippets/appkit/svelte/ton/about/triggermodal.mdx'
 
+import SvelteTronImplementation from '/snippets/appkit/svelte/tron/about/implementation.mdx'
+import SvelteTronModal from '/snippets/appkit/svelte/tron/about/triggermodal.mdx'
+
 # Svelte
 
-AppKit has support for [Wagmi](https://wagmi.sh/) and [Ethers v6](https://docs.ethers.org/v6/) on Ethereum, [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana, Bitcoin and TON.
+AppKit has support for [Wagmi](https://wagmi.sh/) and [Ethers v6](https://docs.ethers.org/v6/) on Ethereum, [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) on Solana, Bitcoin, TON and TRON.
 Choose one of these to get started.
 
 <Note>
@@ -156,6 +159,29 @@ pnpm add @reown/appkit @reown/appkit-adapter-ton
 </CodeGroup>
 
 </Tab>
+<Tab title="TRON">
+
+<CodeGroup>
+
+```bash npm
+npm install @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash Yarn
+yarn add @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash Bun
+bun add @reown/appkit @reown/appkit-adapter-tron
+```
+
+```bash pnpm
+pnpm add @reown/appkit @reown/appkit-adapter-tron
+```
+
+</CodeGroup>
+
+</Tab>
 </Tabs>
 
 ## Cloud Configuration
@@ -199,6 +225,11 @@ MetaMask does not currently support WalletConnect connections on Solana. The Met
 <Tab title="TON">
 
 <SvelteTonImplementation />
+
+</Tab>
+<Tab title="TRON">
+
+<SvelteTronImplementation />
 
 </Tab>
 </Tabs>
@@ -282,6 +313,11 @@ Or use other AppKit web components:
 <Tab title="TON">
 
 <SvelteTonModal />
+
+</Tab>
+<Tab title="TRON">
+
+<SvelteTronModal />
 
 </Tab>
 </Tabs>

--- a/snippets/appkit/svelte/tron/about/implementation.mdx
+++ b/snippets/appkit/svelte/tron/about/implementation.mdx
@@ -36,7 +36,7 @@ if (browser) {
   // Initialize AppKit
   appKit = createAppKit({
     adapters: [tronAdapter],
-    networks: [tronMainnet],
+    networks,
     defaultNetwork: tronMainnet,
     projectId,
     metadata: {

--- a/snippets/appkit/svelte/tron/about/implementation.mdx
+++ b/snippets/appkit/svelte/tron/about/implementation.mdx
@@ -1,0 +1,227 @@
+For this example, we'll be using **TRON**.
+
+Start by importing `createAppKit` from `@reown/appkit` and the necessary chains and TronAdapter from `@reown/appkit-adapter-tron`.
+
+```ts
+// lib/appkit.ts
+import { browser } from '$app/environment'
+import { createAppKit } from '@reown/appkit'
+import { TronAdapter } from '@reown/appkit-adapter-tron'
+import { tronMainnet } from '@reown/appkit/networks'
+
+// Import wallet adapters you want to support
+import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
+
+// Only initialize in browser environment
+let appKit: ReturnType<typeof createAppKit> | undefined = undefined
+
+if (browser) {
+  const projectId = import.meta.env.VITE_PROJECT_ID
+  if (!projectId) {
+    throw new Error('VITE_PROJECT_ID is not set')
+  }
+
+  const networks = [tronMainnet]
+
+  // Create adapter with wallet adapters
+  const tronAdapter = new TronAdapter({
+    walletAdapters: [
+      new TronLinkAdapter({
+        openUrlWhenWalletNotFound: false,
+        checkTimeout: 3000
+      })
+    ]
+  })
+
+  // Initialize AppKit
+  appKit = createAppKit({
+    adapters: [tronAdapter],
+    networks: [tronMainnet],
+    defaultNetwork: tronMainnet,
+    projectId,
+    metadata: {
+      name: 'SvelteKit Example',
+      description: 'SvelteKit Example using TRON adapter',
+      url: 'https://reown.com/appkit',
+      icons: ['https://avatars.githubusercontent.com/u/179229932?s=200&v=4']
+    }
+  })
+}
+
+export { appKit }
+```
+
+<Note>
+  Make sure to set your `VITE_PROJECT_ID` environment variable which you can get from [Reown Dashboard](https://dashboard.reown.com).
+</Note>
+
+<Note>
+  The `browser` check ensures AppKit is only initialized in the browser environment, which is important for SvelteKit's SSR compatibility.
+</Note>
+
+## Install Wallet Adapters
+
+TRON adapter requires you to install wallet adapters separately. This gives you control over which wallets to support and reduces bundle size.
+
+<Tabs>
+<Tab title="TronLink">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-tronlink
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-tronlink
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="MetaMask">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-metamask-tron
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="Trust Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-trust
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-trust
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-trust
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-trust
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="OKX Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-okxwallet
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="BitKeep">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-bitkeep
+```
+
+</CodeGroup>
+</Tab>
+
+<Tab title="Binance Wallet">
+<CodeGroup>
+
+```bash npm
+npm install @tronweb3/tronwallet-adapter-binance
+```
+
+```bash Yarn
+yarn add @tronweb3/tronwallet-adapter-binance
+```
+
+```bash Bun
+bun add @tronweb3/tronwallet-adapter-binance
+```
+
+```bash pnpm
+pnpm add @tronweb3/tronwallet-adapter-binance
+```
+
+</CodeGroup>
+</Tab>
+</Tabs>
+
+<Note>
+For a complete list of available TRON wallet adapters, visit the [official wallet adapter documentation](https://walletadapter.org/docs/guide/wallet-reference.html).
+</Note>
+
+### Using Multiple Wallet Adapters
+
+After installing your desired wallet adapters, import and add them to the `walletAdapters` array when creating the TRON adapter:
+
+```ts
+import { TronLinkAdapter } from '@tronweb3/tronwallet-adapter-tronlink'
+import { MetaMaskAdapter } from '@tronweb3/tronwallet-adapter-metamask-tron'
+import { TrustAdapter } from '@tronweb3/tronwallet-adapter-trust'
+import { OkxWalletAdapter } from '@tronweb3/tronwallet-adapter-okxwallet'
+
+const tronAdapter = new TronAdapter({
+  walletAdapters: [
+    new TronLinkAdapter({
+      openUrlWhenWalletNotFound: false,
+      checkTimeout: 3000
+    }),
+    new MetaMaskAdapter(),
+    new TrustAdapter(),
+    new OkxWalletAdapter({
+      openUrlWhenWalletNotFound: false
+    })
+  ]
+})
+```

--- a/snippets/appkit/svelte/tron/about/triggermodal.mdx
+++ b/snippets/appkit/svelte/tron/about/triggermodal.mdx
@@ -1,0 +1,19 @@
+To open AppKit you can use our [**web component**](/appkit/svelte/core/components) or build your own button with AppKit [**actions**](/appkit/svelte/core/actions#open-and-close-the-modal).
+In this example we are going to use the `<appkit-button>` component.
+
+Web components are global html elements that don't require importing.
+
+```svelte
+<script lang="ts">
+  // Import your AppKit configuration to ensure it's initialized
+  import '$lib/appkit';
+</script>
+
+<main>
+  <h1>Svelte + AppKit Integration</h1>
+  
+  <div class="card">
+    <appkit-button />
+  </div>
+</main>
+```


### PR DESCRIPTION
## Description

Adds TRON network documentation to the Svelte AppKit installation guide, matching the existing TON structure. New TRON tabs are added to the Installation, Implementation, and Trigger the modal sections, along with two new Svelte TRON snippets covering AppKit setup (SSR-safe `browser` guard, `TronAdapter`, `tronMainnet`) and wallet adapter installation/configuration. Content is adapted from the recently added Next.js TRON docs (#788) but follows Svelte/SvelteKit conventions.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.