### PR TITLE
docs: add FAQ on which tokens Reown/WalletConnect support

### DIFF
--- a/appkit/faq.mdx
+++ b/appkit/faq.mdx
@@ -118,6 +118,14 @@ This FAQ section covers common questions and solutions for using AppKit. The que
 ## Features
 
 <AccordionGroup>
+  <Accordion title="Which tokens does Reown / WalletConnect support?">
+    Support is **network-dependent, not token-dependent**. Reown and the WalletConnect protocol don't maintain a list of individual tokens — instead, support is defined at the blockchain level. If a network is supported, then any token on that network (native or otherwise) works automatically.
+
+    AppKit provides native SDK support for EVM chains, Solana, Bitcoin, TON, and TRON. Any token on a supported network is therefore covered.
+
+    For the full list of supported networks, see [Reown AppKit Supported Chains](/appkit/networks/supported-chains#reown-appkit-supported-chains).
+  </Accordion>
+
   <Accordion title="When will Reown support off-ramp functionality?">
     Reown currently does not plan to support off-ramp functionality.
   </Accordion>

--- a/appkit/faq.mdx
+++ b/appkit/faq.mdx
@@ -123,7 +123,7 @@ This FAQ section covers common questions and solutions for using AppKit. The que
 
     AppKit provides native SDK support for EVM chains, Solana, Bitcoin, TON, and TRON. Any token on a supported network is therefore covered.
 
-    For the full list of supported networks, see [Reown AppKit Supported Chains](/appkit/networks/supported-chains#reown-appkit-supported-chains).
+    For the full list of supported networks, see [Reown AppKit Supported Chains](/appkit/networks/supported-chains).
   </Accordion>
 
   <Accordion title="When will Reown support off-ramp functionality?">


### PR DESCRIPTION
## Description

Adds a new FAQ entry to the AppKit FAQs (Features section) answering "Which tokens does Reown / WalletConnect support?". The answer clarifies that support is network-dependent, not token-dependent: any token on a supported network (EVM, Solana, Bitcoin, TON, TRON) works automatically, and links to the Reown AppKit Supported Chains page.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.