### PR TITLE
docs: fix llms.txt summary and broken explorer-submission link

### DIFF
--- a/appkit/faq.mdx
+++ b/appkit/faq.mdx
@@ -193,8 +193,7 @@ This FAQ section covers common questions and solutions for using AppKit. The que
   </Accordion>
 
 <Accordion title="How can I add my web wallet to the wallet list in WalletConnect?">
-  Add your web wallet to WalletConnect by following the steps in this link:
-  https://docs.reown.com/cloud/explorer-submission.
+  Add your web wallet to WalletConnect by following the steps in the [WalletGuide submission guide](https://docs.walletconnect.network/walletguide/explorer-submission).
 </Accordion>
 
 <Accordion title="Can I reinitialize AppKit with different network configurations?">

--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "Reown Docs",
+  "description": "Reown (formerly WalletConnect) developer documentation. Build seamless onchain apps with AppKit — an all-in-one SDK for wallet connections, transactions, email & social logins, on-ramp, swaps, and notifications — and use Reown Cloud to configure projects, analytics, and APIs.",
   "colors": {
     "primary": "#008847",
     "light": "#008847",


### PR DESCRIPTION
## Description

Improves agent-readiness of the docs by addressing two AFDocs check failures. Adds a top-level `description` to `docs.json` so Mintlify emits the required H1 + blockquote summary in the auto-generated `llms.txt`. Fixes a broken link in the AppKit FAQ ("How can I add my web wallet…") that pointed at the now-404 `docs.reown.com/cloud/explorer-submission`, replacing it with the working `docs.walletconnect.network/walletguide/explorer-submission` URL (the canonical destination already used elsewhere in the docs). These remove the only structural broken link in `llms-full.txt` and satisfy the llms.txt structure check.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.