### PR TITLE
docs: remove overly-broad ProGuard rule from AppKit Android install

### DIFF
--- a/appkit/android/core/installation.mdx
+++ b/appkit/android/core/installation.mdx
@@ -48,12 +48,6 @@ If you encounter issues with minification, add the below rules to your applicati
 
 -keep class uniffi.** { *; }
 
-# Preserve all public and protected fields and methods
--keepclassmembers class ** {
-    public *;
-    protected *;
-}
-
 -dontwarn uniffi.**
 -dontwarn com.sun.jna.**
 ```


### PR DESCRIPTION
## Problem

A user reported an issue with the recommended ProGuard rules in the [AppKit Android installation guide](https://docs.reown.com/appkit/android/core/installation#proguard-rules). Specifically this block:

```
# Preserve all public and protected fields and methods
-keepclassmembers class ** {
    public *;
    protected *;
}
```

The complaint is valid:

- **`class **` matches every class in the entire app** — the developer's own code *and all of their other dependencies*, not just the Reown SDK. A rule meant to make our SDK work ends up applying app-wide.
- **`public *; protected *;` keeps all public/protected fields and methods**, so R8/ProGuard can no longer shrink (remove unused members) or obfuscate (rename) them. This largely defeats the purpose of enabling minification:
  - Larger APK / less dead-code elimination
  - No obfuscation of public/protected members → easier reverse engineering, one of the main reasons people enable minification
  - Weaker optimization overall
- **It is unnecessary for the SDK to function.** The genuine native-FFI requirements (the Rust core reached via `uniffi` + JNA) are already covered by the specific rules immediately above it (`com.sun.jna.**`, `uniffi.**`, and the matching `-dontwarn` lines).

Our own [upgrade guide](https://docs.reown.com/appkit/upgrade/from-web3modal-android) (Step 4) already demonstrates the correct, narrowly-scoped pattern — keeping only specific Reown classes (`com.reown.appkit.client.Wallet` / `Wallet$Model`) rather than `**`.

## Change

Removes the broad `class **` block from the ProGuard snippet in `appkit/android/core/installation.mdx`. The JNA and uniffi rules — the real native requirements — are kept.

## ⚠️ Needs Android team review

The Android SDK team should review and **confirm exactly which classes need to survive minification**. If any specific Reown SDK classes genuinely require keeping (e.g. model classes accessed via reflection/serialization), the fix is to add narrowly-scoped `-keep` rules targeting `com.reown.**` classes — *not* a catch-all `class **` rule. The JNA/uniffi rules already cover the documented native requirements, so this docs fix is safe to ship, but the minimal `-keep` set should be confirmed with the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)