### PR TITLE
docs: update AppKit hooks docs for 1.8.19 (accounts, headless wallets)

### DIFF
--- a/appkit/next/core/hooks.mdx
+++ b/appkit/next/core/hooks.mdx
@@ -137,7 +137,7 @@ const bip122Account = useAppKitAccount({ namespace: "bip122" }); // for bitcoin
 
 ### Returns
 
-- `allAccounts`: A list of connected accounts
+- `allAccounts`: A list of connected accounts. Each account includes the `address`, `type`, and `namespace`. Accounts also include `caipAddress` (CAIP-10 format) and `chainId` when network information is available.
 - `address`: The current account address
 - `caipAddress`: The current account address in CAIP format
 - `isConnected`: Boolean that indicates if the user is connected
@@ -156,6 +156,15 @@ type EmbeddedWalletInfo {
 }
 
 type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'reconnecting'
+
+type Account = {
+  namespace: ChainNamespace
+  address: string
+  chainId?: string | number
+  caipAddress?: `${string}:${string}:${string}`
+  type: string
+  publicKey?: string // Available for Bitcoin (bip122) accounts
+}
 
 type UseAppKitAccountReturnType = {
   isConnected: boolean

--- a/appkit/react-native/core/hooks.mdx
+++ b/appkit/react-native/core/hooks.mdx
@@ -117,7 +117,7 @@ export default function MyComponent() {
 - Getting detailed chain information for network-specific features
 
 ### Returns
-- `allAccounts`: Array of all connected accounts across all connections (Account[])
+- `allAccounts`: Array of all connected accounts across all connections. Each account includes `address`, `type`, and `namespace`. Accounts also include `caipAddress` (CAIP-10 format) and `chainId` when network information is available. (Account[])
 - `address`: The connected account address (string)
 - `chainId`: The chain ID of the currently active connection (number or string)
 - `isConnected`: Boolean indicating if a wallet is connected on the current chain/namespace

--- a/appkit/react-native/core/hooks.mdx
+++ b/appkit/react-native/core/hooks.mdx
@@ -132,6 +132,8 @@ The `Account` type has the following structure:
 | `namespace` | `string`       | The blockchain namespace (e.g., 'eip155', 'solana', 'bip122') |
 | `chainId`   | `string`       | The chain ID where this account is active                      |
 | `type`      | `AccountType?` | Optional account type (e.g., 'eoa' or 'smartAccount')         |
+| `caipAddress` | `string?`    | CAIP-10 formatted address. Present when network information is available. |
+| `publicKey` | `string?`      | Bitcoin public key. Only present for Bitcoin (bip122) accounts. |
 
 ## `useProvider()`
 

--- a/appkit/react/core/headless.mdx
+++ b/appkit/react/core/headless.mdx
@@ -112,6 +112,13 @@ const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, w
     include?: string[]
     /** Wallet IDs to exclude. Overrides the default exclude list when provided. */
     exclude?: string[]
+    /**
+     * Include wallets that support WalletConnect Pay but are not v2-compatible.
+     * By default these are filtered out. Enable for WalletConnect Pay surfaces.
+     */
+    includePayOnly?: boolean
+    /** Sort mode. 'wcpay' bubbles WalletConnect Pay-supporting wallets to the top. */
+    sort?: 'default' | 'wcpay'
   }
   ```
 </ResponseField>

--- a/appkit/react/core/headless.mdx
+++ b/appkit/react/core/headless.mdx
@@ -33,7 +33,7 @@ The essential hook for accessing all types of wallets and methods to build your 
 <CodeGroup>
 
 ```tsx useAppKitWallets.tsx
-const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, wcUri, connectingWallet, page, count, fetchWallets, connect, resetWcUri } =
+const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, wcUri, wcError, connectingWallet, page, count, fetchWallets, connect, resetWcUri } =
   useAppKitWallets()
 ```
 
@@ -85,12 +85,35 @@ const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, w
   parameters.
 </ResponseField>
 
+<ResponseField name="wcError" type="boolean">
+  Boolean that indicates if there was an error fetching the WalletConnect URI.
+</ResponseField>
+
 <ResponseField
   name="fetchWallets"
-  type="(options?: { page?: number; query?: string; }) => Promise&lt;void&gt;"
+  type="(options?: FetchWalletsOptions) => Promise&lt;void&gt;"
 >
   Function to fetch WalletConnect wallets from the explorer API. Allows you to list, search, and
   paginate through the wallets.
+
+  ```typescript
+  interface FetchWalletsOptions {
+    /** Page number to fetch (default: 1) */
+    page?: number
+    /** @deprecated Use `search` instead */
+    query?: string
+    /** Search query to filter wallets. When provided, switches to search mode. */
+    search?: string
+    /** Number of entries per page. Defaults to 40 for list mode, 100 for search mode. */
+    entries?: number
+    /** Filter wallets by badge type ('none' | 'certified') */
+    badge?: BadgeType
+    /** Wallet IDs to include. Overrides the global includeWalletIds config when provided. */
+    include?: string[]
+    /** Wallet IDs to exclude. Overrides the default exclude list when provided. */
+    exclude?: string[]
+  }
+  ```
 </ResponseField>
 
 <ResponseField
@@ -356,7 +379,7 @@ function AllWalletsView() {
 
   useEffect(() => {
     if (searchQuery.length > 0) {
-      fetchWallets?.({ query: searchQuery })
+      fetchWallets?.({ search: searchQuery })
     } else {
       fetchWallets?.()
     }
@@ -364,7 +387,7 @@ function AllWalletsView() {
 
   function handleLoadMore() {
     if (searchQuery.length > 0) {
-      fetchWallets?.({ page: page + 1, query: searchQuery })
+      fetchWallets?.({ page: page + 1, search: searchQuery })
     } else {
       fetchWallets?.({ page: page + 1 })
     }

--- a/appkit/react/core/headless.mdx
+++ b/appkit/react/core/headless.mdx
@@ -70,6 +70,10 @@ const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, w
   wallet. Reset with resetWcUri().
 </ResponseField>
 
+<ResponseField name="wcError" type="boolean">
+  Boolean that indicates if there was an error fetching the WalletConnect URI.
+</ResponseField>
+
 <ResponseField name="connectingWallet" type="WalletItem | undefined">
   The wallet currently being connected to. This is set when a connection is initiated and cleared
   when it completes or fails. For WalletConnect wallets, resetWcUri() should be called to clear the
@@ -83,10 +87,6 @@ const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, w
 <ResponseField name="count" type="number">
   The total number of available WalletConnect wallets based on the AppKit configurations and given
   parameters.
-</ResponseField>
-
-<ResponseField name="wcError" type="boolean">
-  Boolean that indicates if there was an error fetching the WalletConnect URI.
 </ResponseField>
 
 <ResponseField
@@ -107,7 +107,7 @@ const { wallets, wcWallets, isFetchingWallets, isFetchingWcUri, isInitialized, w
     /** Number of entries per page. Defaults to 40 for list mode, 100 for search mode. */
     entries?: number
     /** Filter wallets by badge type ('none' | 'certified') */
-    badge?: BadgeType
+    badge?: 'none' | 'certified'
     /** Wallet IDs to include. Overrides the global includeWalletIds config when provided. */
     include?: string[]
     /** Wallet IDs to exclude. Overrides the default exclude list when provided. */

--- a/appkit/react/core/hooks.mdx
+++ b/appkit/react/core/hooks.mdx
@@ -138,7 +138,7 @@ const bip122Account = useAppKitAccount({ namespace: "bip122" }); // for bitcoin
 
 ### Returns
 
-- `allAccounts`: A list of connected accounts
+- `allAccounts`: A list of connected accounts. Each account includes the `address`, `type`, and `namespace`. Accounts also include `caipAddress` (CAIP-10 format) and `chainId` when network information is available.
 - `address`: The current account address
 - `caipAddress`: The current account address in CAIP format
 - `isConnected`: Boolean that indicates if the user is connected
@@ -157,6 +157,15 @@ type EmbeddedWalletInfo {
 }
 
 type ConnectionStatus = 'connected' | 'disconnected' | 'connecting' | 'reconnecting'
+
+type Account = {
+  namespace: ChainNamespace
+  address: string
+  chainId?: string | number
+  caipAddress?: `${string}:${string}:${string}`
+  type: string
+  publicKey?: string // Available for Bitcoin (bip122) accounts
+}
 
 type UseAppKitAccountReturnType = {
   isConnected: boolean
@@ -771,6 +780,7 @@ function WalletManager() {
       address: string;                // Account address
       type?: string;                  // Account type (e.g., "eoa", "smartAccount")
       publicKey?: string;             // Public key (for Bitcoin)
+      caipAddress?: string;           // CAIP-10 formatted address (e.g., "eip155:1:0x...")
     }>;
     caipNetwork?: CaipNetwork;        // Network information
     auth?: {                          // Authentication info (for social logins)

--- a/appkit/vue/core/composables.mdx
+++ b/appkit/vue/core/composables.mdx
@@ -124,6 +124,7 @@ const bip122Account = useAppKitAccount({ namespace: "bip122" }); // for bitcoin
 
 ### Returns
 
+- `accountData.value.allAccounts`: A list of connected accounts. Each account includes the `address`, `type`, and `namespace`. Accounts also include `caipAddress` (CAIP-10 format) and `chainId` when network information is available.
 - `accountData.value.address`: The current account address
 - `accountData.value.caipAddress`: The current account address in CAIP format
 - `accountData.value.isConnected`: Boolean that indicates if the user is connected


### PR DESCRIPTION
## Description

Documents AppKit 1.8.19 changes across framework hook/composable references. Expands `allAccounts` descriptions and adds the `Account` type (including `caipAddress`, `chainId`, and Bitcoin `publicKey`) for Next, React, React Native, and Vue. Updates the React headless `useAppKitWallets` docs with the new `wcError` field and a `FetchWalletsOptions` interface, and migrates examples from the deprecated `query` param to `search`.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.