### PR TITLE
docs: warn that AppKit requires wagmi 2.x on install steps

### DIFF
--- a/appkit/javascript/core/installation.mdx
+++ b/appkit/javascript/core/installation.mdx
@@ -46,6 +46,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/javascript/core/installation.mdx
+++ b/appkit/javascript/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 </CodeGroup>

--- a/appkit/javascript/core/installation.mdx
+++ b/appkit/javascript/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 </CodeGroup>

--- a/appkit/javascript/core/installation.mdx
+++ b/appkit/javascript/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 </CodeGroup>

--- a/appkit/migration/from-connectkit-next.mdx
+++ b/appkit/migration/from-connectkit-next.mdx
@@ -19,6 +19,10 @@ To migrate from ConnectKit to Reown AppKit, please follow the steps below.
 
 - Run this command to install Reown AppKit and uninstall ConnectKit.
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 ```bash npm
 npm install @reown/appkit @reown/appkit-adapter-wagmi && npm uninstall connectkit

--- a/appkit/migration/from-privy-next.mdx
+++ b/appkit/migration/from-privy-next.mdx
@@ -26,19 +26,19 @@ Replace Privy dependencies with AppKit by running the following commands for you
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem && yarn remove @privy-io/react-auth @privy-io/server-auth
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && yarn remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Bun
-bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi viem && bun remove @privy-io/react-auth @privy-io/server-auth
+bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && bun remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
 ```
 </CodeGroup>
 

--- a/appkit/migration/from-privy-next.mdx
+++ b/appkit/migration/from-privy-next.mdx
@@ -26,19 +26,19 @@ Replace Privy dependencies with AppKit by running the following commands for you
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && yarn remove @privy-io/react-auth @privy-io/server-auth
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && yarn remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Bun
-bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && bun remove @privy-io/react-auth @privy-io/server-auth
+bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && bun remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
 ```
 </CodeGroup>
 

--- a/appkit/migration/from-privy-next.mdx
+++ b/appkit/migration/from-privy-next.mdx
@@ -26,19 +26,19 @@ Replace Privy dependencies with AppKit by running the following commands for you
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && npm uninstall @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && yarn remove @privy-io/react-auth @privy-io/server-auth
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && yarn remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash Bun
-bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && bun remove @privy-io/react-auth @privy-io/server-auth
+bun a @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && bun remove @privy-io/react-auth @privy-io/server-auth
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem && pnpm remove @privy-io/react-auth @privy-io/server-auth
 ```
 </CodeGroup>
 

--- a/appkit/migration/from-privy-next.mdx
+++ b/appkit/migration/from-privy-next.mdx
@@ -18,6 +18,11 @@ Follow the steps below to migrate from a default Privy project (using Next.js Pa
 ### Step 2. Install & uninstall libraries
 
 Replace Privy dependencies with AppKit by running the following commands for your preferred package manager:
+
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/migration/from-rainbowkit-next.mdx
+++ b/appkit/migration/from-rainbowkit-next.mdx
@@ -13,6 +13,11 @@ Follow the steps below to migrate from the default RainbowKit project using Next
 ### Step 2. Install & uninstall libraries
 
 - Run this command to install AppKit and uninstall RainbowKit.
+
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 ```bash npm
 npm install @reown/appkit @reown/appkit-adapter-wagmi && npm uninstall @rainbow-me/rainbowkit

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -46,6 +46,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/next/core/installation.mdx
+++ b/appkit/next/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/nuxt/core/installation.mdx
+++ b/appkit/nuxt/core/installation.mdx
@@ -45,19 +45,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
 ```
 
 </CodeGroup>

--- a/appkit/nuxt/core/installation.mdx
+++ b/appkit/nuxt/core/installation.mdx
@@ -38,6 +38,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/nuxt/core/installation.mdx
+++ b/appkit/nuxt/core/installation.mdx
@@ -45,19 +45,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @wagmi/vue @tanstack/vue-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 </CodeGroup>

--- a/appkit/nuxt/core/installation.mdx
+++ b/appkit/nuxt/core/installation.mdx
@@ -45,19 +45,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @wagmi/vue @tanstack/vue-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @wagmi/vue @tanstack/vue-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @wagmi/vue @tanstack/vue-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @wagmi/vue @tanstack/vue-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @wagmi/vue @tanstack/vue-query
 ```
 
 </CodeGroup>

--- a/appkit/react-native/core/installation.mdx
+++ b/appkit/react-native/core/installation.mdx
@@ -89,6 +89,11 @@ Install the adapters for the chains you intend to support:
 
         <p><strong>1. Install Packages:</strong></p>
         <p>First, install the Reown Wagmi adapter and its peer dependencies:</p>
+
+        <Warning>
+          AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+        </Warning>
+
         ```bash
         # Install the Reown Wagmi adapter
         npx expo install @reown/appkit-wagmi-react-native

--- a/appkit/react-native/core/migration-multichain.mdx
+++ b/appkit/react-native/core/migration-multichain.mdx
@@ -49,6 +49,11 @@ Based on the blockchains your dApp needs to support, install the corresponding a
     # yarn add @reown/appkit-ethers-react-native
     ```
 -   **EVM (Wagmi):**
+
+    <Warning>
+      AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+    </Warning>
+
     ```bash
     # For Expo
     npx expo install @reown/appkit-wagmi-react-native wagmi viem@2.x @tanstack/react-query

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -55,19 +55,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -55,19 +55,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -55,19 +55,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem @tanstack/react-query
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem @tanstack/react-query
 ```
 
 </CodeGroup>

--- a/appkit/react/core/installation.mdx
+++ b/appkit/react/core/installation.mdx
@@ -48,6 +48,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -46,6 +46,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm

--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
 ```
 
 </CodeGroup>

--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 </CodeGroup>

--- a/appkit/svelte/core/installation.mdx
+++ b/appkit/svelte/core/installation.mdx
@@ -53,19 +53,19 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <CodeGroup>
 
 ```bash npm
-npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+npm install @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Yarn
-yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+yarn add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash Bun
-bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+bun add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 ```bash pnpm
-pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x @wagmi/connectors@^6.2.0 viem
+pnpm add @reown/appkit @reown/appkit-adapter-wagmi wagmi@2.x viem
 ```
 
 </CodeGroup>

--- a/appkit/upgrade/appkitv2.mdx
+++ b/appkit/upgrade/appkitv2.mdx
@@ -15,6 +15,10 @@ This guide is useful for those that have used a previous AppKit V2 version and a
 
 ### Installation
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <Tabs
 	
 	

--- a/appkit/upgrade/from-web3modal-react-native.mdx
+++ b/appkit/upgrade/from-web3modal-react-native.mdx
@@ -30,6 +30,10 @@ yarn remove @web3modal/wagmi-react-native @web3modal/email-wagmi-react-native @w
 
 Add the new Reown AppKit packages:
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 ```bash
 # Core AppKit library and dependencies
 yarn add @reown/appkit-react-native @react-native-async-storage/async-storage react-native-get-random-values react-native-svg @react-native-community/netinfo @walletconnect/react-native-compat

--- a/appkit/upgrade/to-reown-appkit-web.mdx
+++ b/appkit/upgrade/to-reown-appkit-web.mdx
@@ -23,6 +23,10 @@ This guide will help you upgrade from Web3Modal v5 using Wagmi to the latest Reo
 
 ### Installation
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <Tabs
 	
 	
@@ -537,6 +541,10 @@ The following methods and listeners are exactly the same and do not have any spe
 
 ### Installation
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <Tabs
 	
 	
@@ -953,6 +961,10 @@ Learn more about integrating Reown AppKit with JavaScript [here](../javascript/c
 ## Web3Modal v3 to Reown AppKit - Web | Wagmi
 
 ### Installation
+
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
 
 <Tabs
 	

--- a/appkit/vue/core/installation.mdx
+++ b/appkit/vue/core/installation.mdx
@@ -40,6 +40,10 @@ After installation, you can ask your AI assistant for help with AppKit setup, im
 <Tabs>
 <Tab title="Wagmi">
 
+<Warning>
+  AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version.
+</Warning>
+
 <CodeGroup>
 
 ```bash npm


### PR DESCRIPTION
## Description

Adds a `<Warning>` callout stating "AppKit is only compatible with wagmi 2.x. Ensure you are using a compatible version." to every installation, migration, and upgrade guide that instructs users to install wagmi. This covers the core framework install pages (React, Next, Vue, Nuxt, JavaScript, Svelte, React Native), the migration guides (RainbowKit, ConnectKit, Privy, RN multichain), and the upgrade guides (to-reown-appkit-web, appkitv2, from-web3modal-react-native). The goal is to prevent users from pulling in an incompatible wagmi version.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)