### PR TITLE
docs: update AppKit RN example links after appkit-wagmi migration

### DIFF
--- a/appkit/react-native/core/installation.mdx
+++ b/appkit/react-native/core/installation.mdx
@@ -601,7 +601,7 @@ module.exports = createRunOncePlugin(
 1. Open your `Info.plist` file.
 2. Locate the `<key>LSApplicationQueriesSchemes</key>` section.
 3. Add the desired wallet schemes as string entries within the `<array>`. These schemes represent the wallets you want to detect.
-4. Refer to our [Info.plist example file](https://github.com/reown-com/react-native-examples/blob/main/dapps/W3MWagmi/ios/W3MWagmi/Info.plist#L41) for a detailed illustration.
+4. Refer to our [Info.plist example file](https://github.com/reown-com/react-native-examples/blob/main/dapps/W3MEthers/ios/Web3ModalEthers/Info.plist#L38) for a detailed illustration.
 
 Example:
 
@@ -624,7 +624,7 @@ Example:
 1. Open your `AndroidManifest.xml` file.
 2. Locate the `<queries>` section.
 3. Add the desired wallet package names as `<package>` entries within the `<queries>`. These package names correspond to the wallets you want to detect.
-4. Refer to our [AndroidManifest.xml example file](https://github.com/reown-com/react-native-examples/blob/main/dapps/W3MWagmi/android/app/src/main/AndroidManifest.xml#L5) for detailed guidance.
+4. Refer to our [AndroidManifest.xml example file](https://github.com/reown-com/react-native-examples/blob/main/dapps/W3MEthers/android/app/src/main/AndroidManifest.xml#L4) for detailed guidance.
 
 Example:
 
@@ -787,7 +787,7 @@ export const appKit = createAppKit({
   <Card
     title="AppKit with Wagmi example"
     icon="github"
-    href="https://github.com/reown-com/react-native-examples/tree/main/dapps/W3MWagmi"
+    href="https://github.com/reown-com/react-native-examples/tree/main/dapps/appkit-wagmi"
   >
     Check the React Native example using Wagmi
   </Card>


### PR DESCRIPTION
## Summary

Follow-up to [react-native-examples#568](https://github.com/reown-com/react-native-examples/pull/568), which renamed `dapps/W3MWagmi` → `dapps/appkit-wagmi` and migrated it to Expo. Updates the affected links in the AppKit React Native installation docs.

## Changes

All in `appkit/react-native/core/installation.mdx`:

- **Wagmi example card** → now points to `dapps/appkit-wagmi` (renamed folder).
- **RN CLI Info.plist / AndroidManifest example links** → repointed from `W3MWagmi` to `W3MEthers`. Because `appkit-wagmi` now uses Expo CNG, its `ios/` and `android/` folders are no longer committed, so those native-file links would 404. `W3MEthers` is still a bare React Native CLI project, making it the correct reference for the "React Native CLI" tab.
  - iOS: `W3MEthers/ios/Web3ModalEthers/Info.plist#L38`
  - Android: `W3MEthers/android/app/src/main/AndroidManifest.xml#L4`

## Notes

- react-native-examples#568 is merged; `dapps/appkit-wagmi` and all referenced files exist on `main`, so every link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)