### PR TITLE
docs: add FAQ for Vercel @wagmi/core tempo specifier error

### DIFF
--- a/appkit/faq.mdx
+++ b/appkit/faq.mdx
@@ -375,6 +375,26 @@ This FAQ section covers common questions and solutions for using AppKit. The que
 
   </Accordion>
 
+  <Accordion title="Why does my Vercel deployment fail with a 'Missing ./tempo specifier in @wagmi/core' error?">
+    When deploying to Vercel, your build may fail with an error like:
+
+    ```bash
+    Missing "./tempo" specifier in "@wagmi/core" package
+    error TS2322: Type 'import("/vercel/path0/react/react-wagmi/node_modules/@wagmi/core/dist/types/createConfig")
+    ```
+
+    This is caused by a version mismatch between `@wagmi/core` and `@wagmi/connectors`. To resolve it, add `@wagmi/connectors` at version `6.2.0` to your dependencies:
+
+    ```json
+    "dependencies": {
+      "@wagmi/connectors": "6.2.0"
+    }
+    ```
+
+    Then reinstall your dependencies and redeploy.
+
+  </Accordion>
+
   <Accordion title="Error Codes">
     Below is a list of error codes you may encounter when using AppKit, along with their descriptions and recommended actions:
 


### PR DESCRIPTION
## Description

Adds a new AppKit FAQ entry in the Technical section addressing the Vercel deployment failure `Missing "./tempo" specifier in "@wagmi/core" package` (with the accompanying `TS2322` type error). The entry explains the cause (a version mismatch between `@wagmi/core` and `@wagmi/connectors`) and the fix: add `@wagmi/connectors` at version `6.2.0` to dependencies, then reinstall and redeploy.

## Tests

- [ ] - Ran the changes locally with Mintlify and confirmed that the changes appear as expected.
- [ ] - Ran a grammar check on the updated/created content using ChatGPT.

## Direct links to the deployed changes in Mintlify.